### PR TITLE
fix(component): Fix PatternListContainer unique key error

### DIFF
--- a/src/component/container/pattern_list.tsx
+++ b/src/component/container/pattern_list.tsx
@@ -99,8 +99,8 @@ export class PatternListContainer extends React.Component<PatternListContainerPr
 				{items.map((props: PatternListContainerItemProps, index: number) => {
 					if (props.children) {
 						return (
-							<PatternList>
-								<PatternLabel key={index}>{props.value}</PatternLabel>
+							<PatternList key={index}>
+								<PatternLabel>{props.value}</PatternLabel>
 								{this.createList(props.children)}
 							</PatternList>
 						);


### PR DESCRIPTION
This PR fixes the unique key error for PatternListContainer. The key should be the on the wrapper, not the child and the PR just moves it up 👍 

```js
/Applications/Alva.app/Contents/Resources/app.asar/node_modules/fbjs/lib/warning.js:33 Warning: Each child in an array or iterator should have a unique "key" prop.

Check the render method of `PatternListContainer`. See https://fb.me/react-warning-keys for more information.
    in PatternList (created by PatternListContainer)
    in PatternListContainer (created by App)
    in div (created by styled.div)
    in styled.div (created by PatternsPane)
    in PatternsPane (created by App)
    in div (created by styled.div)
    in styled.div (created by Styled(styled.div))
    in Styled(styled.div)
    in Unknown (created by App)
    in div (created by styled.div)
    in styled.div (created by Styled(styled.div))
    in Styled(styled.div)
    in Unknown (created by App)
    in div (created by styled.div)
    in styled.div (created by Layout)
    in Layout (created by App)
    in App
```