### PR TITLE
fix: disable unhandled file dragging

### DIFF
--- a/src/electron/electron.ts
+++ b/src/electron/electron.ts
@@ -36,6 +36,11 @@ function createWindow(): void {
 		win = undefined;
 	});
 
+	// Disable navigation on the host window object, triggered by system drag and drop
+	win.webContents.on('will-navigate', e => {
+		e.preventDefault();
+	});
+
 	let devToolsInstaller;
 	try {
 		devToolsInstaller = require('electron-devtools-installer');


### PR DESCRIPTION
This disables dragging interaction on the main window of the application, e.g. when
pulling files from onto the application.

Before this change the entire application was blanked. By preventing the resulting
navigation event this does not happen after this change

related to #177