### PR TITLE
fix(142): tslint-no-console-log

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -63,7 +63,7 @@
 		"no-arg": true,
 		"no-bitwise": true,
 		"no-conditional-assignment": true,
-		"no-console": [false],
+		"no-console": { "severity": "warning", "options": ["log", "info", "debug", "trace"] },
 		"no-construct": true,
 		"no-debugger": true,
 		"no-duplicate-super": true,


### PR DESCRIPTION
#142 
Modifies tslint rule for console to throw a warning for console.log, .info, etc. 
console.warn() and error() should still work without errors. I wanted to add the ability to have TSlint stop when building for production while warnings are present but this doesn't appear to be possible with that linter. 

If this is not desired, feel free to reject this PR. 