### PR TITLE
fix(menu): it is not possible to call toggleDevTools on browserWindow

### DIFF
--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -4,7 +4,6 @@ import {
 	MenuItem,
 	MenuItemConstructorOptions,
 	remote,
-	WebContents,
 	WebviewTag
 } from 'electron';
 import * as FileExtraUtils from 'fs-extra';
@@ -298,9 +297,9 @@ export function createMenu(store: Store): void {
 							return 'Ctrl+Shift+I';
 						}
 					})(),
-					click: (item: MenuItem, focusedWindow: WebContents) => {
+					click: (item: MenuItem, focusedWindow: BrowserWindow) => {
 						if (focusedWindow) {
-							focusedWindow.toggleDevTools();
+							focusedWindow.webContents.toggleDevTools();
 						}
 					}
 				}


### PR DESCRIPTION
focusedWindow is of type BrowserWindow and was converted to type WebContents to be able to trigger toggleDevTools on it. The better way it to get webContents from focusedWindow and then call toggleDevTools