### PR TITLE
fix(build): add react typings to distributed designkit

### DIFF
--- a/scripts/dist-preprocess.js
+++ b/scripts/dist-preprocess.js
@@ -15,7 +15,8 @@ execSync(`
 	npm i &&
 	npm run build &&
 	rm -rf node_modules &&
-	npm i --production
+	npm i --production &&
+	npm i @types/react
 `, {
 		cwd: 'build/designkit'
 	}


### PR DESCRIPTION
styleguides need to provide react typings due to the new pattern export detection introduced with the StyleguideAnalyzer. The designkit distributed with the build didn't do this before. Without the typings the analyzer is not able to detect react component exports. This fixes the Create Styleguide function.