### PR TITLE
build(scripts): get latest designkit master on build

### DIFF
--- a/scripts/dist-preprocess.js
+++ b/scripts/dist-preprocess.js
@@ -6,9 +6,9 @@ execSync('npm run build:clean');
 
 console.info('Starting to copy designkit to build folder.');
 execSync(`
-	mkdir build/designkit &&
-	cp -r ../designkit/patterns ../designkit/alva ../designkit/*.* build/designkit/
-`);
+	git clone git@github.com:meetalva/designkit.git --depth=1 build/designkit &&
+	rm -r build/designkit/.[^.]*
+`)
 
 console.info('Install node packages for designkit.');
 execSync(`


### PR DESCRIPTION
Get the latest designkit master from github when building a release instead of using the local one.

**Why:**
The latest release (`0.7.0`) includes a more or less broken version of designkit because it has its dependencies messed up which makes it unbuildable today. As far as I can see the version contained in `0.7.0` was never a master of `meetalva/designkit` but just a local version of whom evers machine while building the release.

This is now prevented to happen again 🎉!