### PR TITLE
fix(object-property): infinite loop on type recursion

### DIFF
--- a/src/component/container/property-list.tsx
+++ b/src/component/container/property-list.tsx
@@ -99,7 +99,7 @@ class PropertyTree extends React.Component<PropertyTreeProps> {
 
 		return (
 			<Element title={property.getName()} open={this.isOpen} handleClick={this.handleClick}>
-				{this.renderItems()}
+				{this.isOpen ? this.renderItems() : 'hidden'}
 			</Element>
 		);
 	}

--- a/src/store/styleguide/property/object-property.ts
+++ b/src/store/styleguide/property/object-property.ts
@@ -1,5 +1,7 @@
 import { Property } from './property';
 
+export type PropertyResolver = () => Property[];
+
 /**
  * An object property is a property that supports objects with nested property values.
  * The properties field declares the types of each object element.
@@ -11,7 +13,9 @@ export class ObjectProperty extends Property {
 	/**
 	 * The nested properties this property supports in its object values.
 	 */
-	private properties: Map<string, Property> = new Map();
+	private properties?: Map<string, Property>;
+
+	private propertyResolver?: PropertyResolver;
 
 	/**
 	 * Creates a new object property.
@@ -39,7 +43,7 @@ export class ObjectProperty extends Property {
 	 * @return The nested properties this property supports.
 	 */
 	public getProperties(): Property[] {
-		return Array.from(this.properties.values());
+		return Array.from(this.resolveProperties().values());
 	}
 
 	/**
@@ -48,7 +52,7 @@ export class ObjectProperty extends Property {
 	 * @return The nested property if the ID was found.
 	 */
 	public getProperty(id: string): Property | undefined {
-		return this.properties.get(id);
+		return this.resolveProperties().get(id);
 	}
 
 	/**
@@ -58,16 +62,30 @@ export class ObjectProperty extends Property {
 		return 'object';
 	}
 
+	private resolveProperties(): Map<string, Property> {
+		if (!this.properties) {
+			if (!this.propertyResolver) {
+				throw new Error('property resolver is not set');
+			}
+
+			const resolvedProperties = this.propertyResolver();
+			const properties = new Map();
+
+			resolvedProperties.forEach(property => properties.set(property.getId(), property));
+
+			this.properties = properties;
+		}
+
+		return this.properties;
+	}
+
 	/**
 	 * Sets The nested properties this property supports in its object values.<br>
 	 * <b>Note:</b> This method should only be called from the pattern parsers.
 	 * @param properties The nested properties this property supports.
 	 */
-	public setProperties(properties: Property[]): void {
-		this.properties = new Map();
-		for (const property of properties) {
-			this.properties.set(property.getId(), property);
-		}
+	public setPropertyResolver(propertyResolver: PropertyResolver): void {
+		this.propertyResolver = propertyResolver;
 	}
 
 	/**

--- a/src/styleguide/analyzer/typescript-react-analyzer/property-analyzer.ts
+++ b/src/styleguide/analyzer/typescript-react-analyzer/property-analyzer.ts
@@ -214,7 +214,9 @@ export class PropertyAnalyzer {
 
 			if (objectType.objectFlags & ts.ObjectFlags.Interface) {
 				const property = new ObjectProperty(args.symbol.name);
-				property.setProperties(PropertyAnalyzer.analyze(args.type, args.typechecker));
+				property.setPropertyResolver(() =>
+					PropertyAnalyzer.analyze(args.type, args.typechecker)
+				);
 				return property;
 			}
 		}


### PR DESCRIPTION
Object types have been expanded at creation time which means that the following code within a components prop type declarations would lead to an ifinite loop.

```
export interface FooProps {
  test: string;
  bar: BarProps;
}

export interface BarProps {
  foo: FooProps;
}
```

Object properties will now be expanded at render time (only if the user expands them in the property pane).