### PR TITLE
chore: switch html-sketchapp dep back to brainly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,17 @@
         }
       }
     },
+    "@brainly/html-sketchapp": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@brainly/html-sketchapp/-/html-sketchapp-3.0.2.tgz",
+      "integrity": "sha512-HjUCvo0FRbAJhHNds3rJlCb6JJTcFdLxWzFLYqS1PgQAE4AQmOJ5tlKUMC1980ZxniZ83jGoo/rwTFhIYNk+QQ==",
+      "requires": {
+        "murmur2js": "1.0.0",
+        "normalize-css-color": "1.0.2",
+        "sketch-constants": "1.1.0",
+        "sketchapp-json-plugin": "0.1.2"
+      }
+    },
     "@commitlint/cli": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-6.1.3.tgz",
@@ -1383,17 +1394,6 @@
       "resolved": "https://registry.npmjs.org/@patternplate/websocket-client/-/websocket-client-2.1.6.tgz",
       "integrity": "sha1-zEgH4uK84ziPKdi2muvM0Kbbkd8=",
       "dev": true
-    },
-    "@thereincarnator/html-sketchapp": {
-      "version": "2.1.0-11",
-      "resolved": "https://registry.npmjs.org/@thereincarnator/html-sketchapp/-/html-sketchapp-2.1.0-11.tgz",
-      "integrity": "sha1-X/p/ooQEOp7M7KS3q0j5XZ4heno=",
-      "requires": {
-        "murmur2js": "1.0.0",
-        "normalize-css-color": "1.0.2",
-        "sketch-constants": "1.1.0",
-        "sketchapp-json-plugin": "0.1.2"
-      }
     },
     "@types/chokidar": {
       "version": "1.7.5",
@@ -6775,8 +6775,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "typedoc": "0.11.1"
   },
   "dependencies": {
-    "@thereincarnator/html-sketchapp": "2.1.0-11",
+    "@brainly/html-sketchapp": "3.0.2",
     "chokidar": "2.0.3",
     "cli": "1.0.1",
     "deep-assign": "2.0.0",

--- a/src/export/sketch-exporter.ts
+++ b/src/export/sketch-exporter.ts
@@ -1,4 +1,4 @@
-import * as HtmlSketchApp from '@thereincarnator/html-sketchapp';
+import * as HtmlSketchApp from '@brainly/html-sketchapp';
 import { ipcRenderer, WebviewTag } from 'electron';
 import { Exporter, ExportResult } from './exporter';
 import { Page } from '../store/page/page';


### PR DESCRIPTION
This PR switches back from the fork of html-sketchapp to the official NPM module, after the author has now released a new version.