### PR TITLE
chore: prevent log files from ending up in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 dist
 designkit
 node_modules
+*.log


### PR DESCRIPTION
This prevents `*.log` files generated by npm from ending up in the repo