### PR TITLE
chore(deps): remove unused ts-config dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "prettier": "1.12.0",
     "mock-fs": "4.4.2",
     "standard-version": "4.3.0",
-    "ts-config": "17.0.0",
     "ts-jest": "22.4.2",
     "tslint": "5.9.1",
     "typedoc": "0.11.1"


### PR DESCRIPTION
Neither tslint.json nor tsconfig.json use ts-config as a base. Therefor the dependency can be removed.

If this gets merged #360 should be closed.