### PR TITLE
chore: split start and watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "dist": "node ./scripts/dist-preprocess.js",
     "docs": "typedoc src",
     "lint": "tslint --project . -c tslint.json 'src/**/*.ts'",
-    "start": "npm run build && concurrently \"electron build/electron/main.js --remote-debugging-port=9222 --inspect=9223\" \"tsc --project . --watch\"",
+    "start": "npm run build && electron build/electron/main.js --remote-debugging-port=9222 --inspect=9223",
     "start:clean": "npm run clean && npm run start",
     "start:lsg": "npm run build:lsg && concurrently \"npm run build:lsg -- -w\" \"patternplate start\"",
     "precommit": "lint-staged",
+    "watch": "npm run build && concurrently \"electron build/electron/main.js --remote-debugging-port=9222 --inspect=9223\" \"tsc --project . --watch\"",
+    "watch:clean": "npm run clean && npm run watch",
     "watch:tests": "jest --watch",
     "test": "jest"
   },


### PR DESCRIPTION
Hello people,
I'd like to split the start and watch npm scripts.
On Windows machines, watching often causes terminal hangs and forced restarts,
and for main-process debugging, watching doesn't help anyway.
I'd like to start without watching, while others may do with.