### PR TITLE
feat(store): prepare basic events and variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3544,15 +3544,6 @@
       "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
-    "comment-json": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
-      "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
-      "dev": true,
-      "requires": {
-        "json-parser": "1.1.5"
-      }
-    },
     "common-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-dir/-/common-dir-1.0.1.tgz",
@@ -9491,15 +9482,6 @@
       "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
-    "json-parser": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
-      "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
-      "dev": true,
-      "requires": {
-        "esprima": "2.7.3"
-      }
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -14294,15 +14276,6 @@
       "dev": true,
       "requires": {
         "utf8-byte-length": "1.0.4"
-      }
-    },
-    "ts-config": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ts-config/-/ts-config-17.0.0.tgz",
-      "integrity": "sha512-6lectaA+utD2vvlf0T8tkwX1SOhMClv5wAlC8SRsN5fa/pSo1WcplrNZp1Vxst0zlfaLHJqUQrx9c128AiHkQQ==",
-      "dev": true,
-      "requires": {
-        "comment-json": "1.1.3"
       }
     },
     "ts-jest": {

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -93,11 +93,30 @@ async function createWindow(): Promise<void> {
 					});
 					break;
 				}
+
 				case PreviewMessageType.SketchExportResponse: {
 					send({
 						id: message.id,
 						payload: message.payload,
 						type: ServerMessageType.SketchExportResponse
+					});
+					break;
+				}
+
+				case PreviewMessageType.OpenPage: {
+					send({
+						id: message.id,
+						payload: message.payload,
+						type: ServerMessageType.OpenPage
+					});
+					break;
+				}
+
+				case PreviewMessageType.SetVariable: {
+					send({
+						id: message.id,
+						payload: message.payload,
+						type: ServerMessageType.SetVariable
 					});
 				}
 			}

--- a/src/electron/renderer.ts
+++ b/src/electron/renderer.ts
@@ -19,9 +19,20 @@ ipcRenderer.on('message', (e: Electron.Event, message: any) => {
 	if (!message) {
 		return;
 	}
+
 	switch (message.type) {
 		case 'start-app': {
 			store.setServerPort(message.payload);
+			break;
+		}
+
+		case 'open-page': {
+			store.openPage(message.payload);
+			break;
+		}
+
+		case 'set-variable': {
+			store.setVariableValue(message.payload.variable, message.payload.inputValue);
 		}
 	}
 });

--- a/src/electron/server.ts
+++ b/src/electron/server.ts
@@ -173,16 +173,19 @@ export async function createServer(opts: ServerOptions): Promise<EventEmitter> {
 				}
 				break;
 			}
+
 			case ServerMessageType.PageChange: {
 				state.payload.page = message.payload;
 				send(state);
 				break;
 			}
+
 			case ServerMessageType.ElementChange: {
 				state.payload.elementId = message.payload;
 				send(message);
 				break;
 			}
+
 			case ServerMessageType.BundleChange: {
 				send({
 					type: 'reload',
@@ -191,14 +194,17 @@ export async function createServer(opts: ServerOptions): Promise<EventEmitter> {
 				});
 				break;
 			}
+
 			case ServerMessageType.AppLoaded: {
 				break;
 			}
+
 			case ServerMessageType.SketchExportRequest:
 			case ServerMessageType.ContentRequest: {
 				send(message);
 				break;
 			}
+
 			default: {
 				console.warn(`Unknown message type: ${message.type}`);
 			}

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -2,7 +2,9 @@ export enum PreviewMessageType {
 	ContentRequest = 'content-request',
 	ContentResponse = 'content-response',
 	ElementChange = 'element-change',
+	OpenPage = 'open-page',
 	Reload = 'reload',
+	SetVariable = 'set-variable',
 	SketchExportRequest = 'sketch-export-request',
 	SketchExportResponse = 'sketch-export-response',
 	State = 'state',
@@ -15,7 +17,9 @@ export enum ServerMessageType {
 	ContentRequest = 'content-request',
 	ContentResponse = 'content-response',
 	ElementChange = 'element-change',
+	OpenPage = 'open-page',
 	PageChange = 'page-change',
+	SetVariable = 'set-variable',
 	SketchExportRequest = 'sketch-export-request',
 	SketchExportResponse = 'sketch-export-response',
 	StartApp = 'start-app',
@@ -31,12 +35,19 @@ export interface Envelope<V, T> {
 export type ServerMessage =
 	| ContentRequest
 	| ContentResponse
+	| OpenPageMessage
+	| SetVariableMessage
 	| SketchExportRequest
 	| SketchExportResponse
 	| StartAppMessage;
 
-export type StartAppMessage = Envelope<ServerMessageType.StartApp, string>;
 export type ContentRequest = Envelope<ServerMessageType.ContentRequest, undefined>;
 export type ContentResponse = Envelope<ServerMessageType.ContentResponse, string>;
+export type OpenPageMessage = Envelope<ServerMessageType.OpenPage, string>;
+export type SetVariableMessage = Envelope<
+	ServerMessageType.SetVariable,
+	{ inputValue: string; variable: string }
+>;
 export type SketchExportRequest = Envelope<ServerMessageType.SketchExportRequest, undefined>;
 export type SketchExportResponse = Envelope<ServerMessageType.SketchExportResponse, string>;
+export type StartAppMessage = Envelope<ServerMessageType.StartApp, string>;

--- a/src/preview/preview.tsx
+++ b/src/preview/preview.tsx
@@ -45,6 +45,7 @@ function main(): void {
 	const render = () => {
 		// tslint:disable-next-line:no-any
 		(window as any).renderer.render({
+			connection,
 			getComponent,
 			highlight,
 			store
@@ -69,20 +70,24 @@ function main(): void {
 				window.location.reload();
 				break;
 			}
+
 			case PreviewMessageType.Update: {
 				Promise.all([refetch('renderer'), refetch('components')]).then(() => {
 					render();
 				});
 				break;
 			}
+
 			case PreviewMessageType.State: {
 				store.page = payload.page;
 				break;
 			}
+
 			case PreviewMessageType.ElementChange: {
 				store.elementId = payload;
 				break;
 			}
+
 			case PreviewMessageType.ContentRequest: {
 				const rec = document.documentElement.getBoundingClientRect();
 
@@ -101,6 +106,7 @@ function main(): void {
 
 				break;
 			}
+
 			case PreviewMessageType.SketchExportRequest: {
 				const sketchPage = HtmlSketchApp.nodeTreeToSketchPage(document.documentElement, {
 					pageName: payload.pageName,

--- a/src/store/page/page-element.ts
+++ b/src/store/page/page-element.ts
@@ -1,4 +1,5 @@
 import * as deepAssign from 'deep-assign';
+import { EventAction } from '../styleguide/property/event/event-action';
 import { JsonArray, JsonObject, JsonValue } from '../json';
 import * as MobX from 'mobx';
 import * as ObjectPath from 'object-path';
@@ -369,7 +370,9 @@ export class PageElement {
 	 * @return The JSON value.
 	 */
 	protected propertyToJsonValue(value: PropertyValue): JsonValue {
-		if (value instanceof Object) {
+		if (value instanceof EventAction) {
+			return value.toJsonObject();
+		} else if (value instanceof Object) {
 			const jsonObject: JsonObject = {};
 			Object.keys(value).forEach((propertyId: string) => {
 				// tslint:disable-next-line:no-any
@@ -499,7 +502,7 @@ export class PageElement {
 	}
 
 	/**
-	 * Serializes the page element into a JSON object for persistence.
+	 * Serializes the page element into a JSON object for persistence or transport.
 	 * @param forRendering Whether all property values should be converted using
 	 * Property.convertToRender (for the preview app instead of file persistence).
 	 * @return The JSON object to be persisted.

--- a/src/store/page/property-value.ts
+++ b/src/store/page/property-value.ts
@@ -1,3 +1,5 @@
+import { EventAction } from '../styleguide/property/event/event-action';
+
 /**
  * The valid types for each property value, mainly primitives, objects of primitives,
  * page elements, and some arrays.
@@ -9,5 +11,6 @@ export type PropertyValue =
 	| number
 	| number[]
 	| boolean
+	| EventAction
 	| undefined
 	| null;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,6 +12,7 @@ import { PageRef } from './page/page-ref';
 import * as Path from 'path';
 import { Preferences } from './preferences';
 import { Project } from './project';
+import { PropertyValue } from './page/property-value';
 import { Styleguide } from './styleguide/styleguide';
 
 export enum RightPane {
@@ -134,6 +135,14 @@ export class Store {
 	 * The last command in the list is the most recent executed one.
 	 */
 	@MobX.observable private undoBuffer: Command[] = [];
+
+	/**
+	 * Variables are property values edited by the user while testing pages.
+	 * They receive their values from property event handlers, and can bind to other properties,
+	 * providing a way to transfer data e.g. from an input to a summary page.
+	 * Variables are not persisted in the styleguide.
+	 */
+	@MobX.observable private variableValues: Map<string, PropertyValue> = new Map();
 
 	/**
 	 * Creates a new store.
@@ -472,6 +481,27 @@ export class Store {
 	 */
 	public getStyleguide(): Styleguide | undefined {
 		return this.styleguide;
+	}
+
+	/**
+	 * Returns the names of all variables currently registered.
+	 * @return The names of all variables.
+	 */
+	public getVariableNames(): string[] {
+		return Array.from(this.variableValues.keys());
+	}
+
+	/**
+	 * Returns the current value of a variable.
+	 * Note: Variables are property values edited by the user while testing pages.
+	 * They receive their values from property event handlers, and can bind to other properties,
+	 * providing a way to transfer data e.g. from an input to a summary page.
+	 * Variables are not persisted in the styleguide.
+	 * @param id The ID of the variable (global to the styleguide).
+	 * @return The current property value.
+	 */
+	public getVariableValue(id: string): PropertyValue {
+		return this.variableValues.get(id);
 	}
 
 	/**
@@ -916,6 +946,19 @@ export class Store {
 		}
 
 		this.clearUndoRedoBuffers();
+	}
+
+	/**
+	 * Sets a variable value and updates all pattern properties that use variables.
+	 * Note: Variables are property values edited by the user while testing pages.
+	 * They receive their values from property event handlers, and can bind to other properties,
+	 * providing a way to transfer data e.g. from an input to a summary page.
+	 * Variables are not persisted in the styleguide.
+	 * @param id The ID of the variable (global to the styleguide).
+	 * @param value The new property value.
+	 */
+	public setVariableValue(id: string, value: PropertyValue): void {
+		this.variableValues.set(id, value);
 	}
 
 	/**

--- a/src/store/styleguide/property/enum-property.ts
+++ b/src/store/styleguide/property/enum-property.ts
@@ -64,8 +64,8 @@ export class EnumProperty extends Property {
 	 * @inheritdoc
 	 */
 	// tslint:disable-next-line:no-any
-	public convertToRender(value: any): any {
-		return this.ordinalById[value as string];
+	public convertToRender(value: string): number {
+		return this.ordinalById[value];
 	}
 
 	/**

--- a/src/store/styleguide/property/event/event-action.ts
+++ b/src/store/styleguide/property/event/event-action.ts
@@ -1,0 +1,12 @@
+import { JsonObject } from '../../../json';
+
+/**
+ * The first parameter of these functions must be the DOM event (e.g. click, change).
+ */
+export abstract class EventAction {
+	/**
+	 * Serializes the event action into a JSON object for persistence or transport.
+	 * @return The JSON object to be persisted.
+	 */
+	public abstract toJsonObject(): JsonObject;
+}

--- a/src/store/styleguide/property/event/event-property.ts
+++ b/src/store/styleguide/property/event/event-property.ts
@@ -1,0 +1,58 @@
+import { EventAction } from './event-action';
+import { OpenPageAction } from './open-page-action';
+import { Property } from '../property';
+import { SetVariableAction } from './set-variable-action';
+
+/**
+ * An event property is a property that takes EventActions to generate handler functions
+ * for UI events.
+ * @see Property
+ */
+export class EventProperty extends Property {
+	/**
+	 * Creates a new boolean property.
+	 * @param id The technical ID of this property (e.g. the property name
+	 * in the TypeScript props interface).
+	 */
+	public constructor(id: string) {
+		super(id);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	// tslint:disable-next-line:no-any
+	public coerceValue(value: any): any {
+		if (value instanceof EventAction) {
+			return value;
+		} else if (
+			value &&
+			value._type === 'set-variable-event-action' &&
+			typeof value.variable === 'string'
+		) {
+			return new SetVariableAction({ variable: value.variable as string });
+		} else if (
+			value &&
+			value._type === 'open-page-event-action' &&
+			typeof value.pageId === 'string'
+		) {
+			return new OpenPageAction({ pageId: value.pageId as string });
+		} else {
+			return undefined;
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public getType(): string {
+		return 'event';
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public toString(): string {
+		return `EventProperty(${super.toString()})`;
+	}
+}

--- a/src/store/styleguide/property/event/open-page-action.ts
+++ b/src/store/styleguide/property/event/open-page-action.ts
@@ -1,0 +1,39 @@
+import { EventAction } from './event-action';
+import { JsonObject } from '../../../json';
+
+/**
+ * The first parameter of these functions must be the DOM event (e.g. click, change).
+ */
+export class OpenPageAction extends EventAction {
+	/**
+	 * The ID of the page to open.
+	 */
+	private pageId: string;
+
+	/**
+	 * Creates a new open-page action.
+	 * @param pageId The ID of the page to open on events.
+	 */
+	public constructor(props: { pageId: string }) {
+		super();
+		this.pageId = props.pageId;
+	}
+
+	/**
+	 * Returns the ID of the page to open.
+	 * @return The ID of the page to open.
+	 */
+	public getPageId(): string {
+		return this.pageId;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public toJsonObject(): JsonObject {
+		return {
+			_type: 'open-page-event-action',
+			pageId: this.pageId
+		};
+	}
+}

--- a/src/store/styleguide/property/event/set-variable-action.ts
+++ b/src/store/styleguide/property/event/set-variable-action.ts
@@ -1,0 +1,39 @@
+import { EventAction } from './event-action';
+import { JsonObject } from '../../../json';
+
+/**
+ * The first parameter of these functions must be the DOM event (e.g. click, change).
+ */
+export class SetVariableAction extends EventAction {
+	/**
+	 * The name of the variable to set on events.
+	 */
+	private variable: string;
+
+	/**
+	 * Creates a new set-variable action
+	 * @param variable The name of the variable to set on events.
+	 */
+	public constructor(props: { variable: string }) {
+		super();
+		this.variable = props.variable;
+	}
+
+	/**
+	 * Returns the name of the variable to set on events.
+	 * @return The name of the variable.
+	 */
+	public getVariable(): string {
+		return this.variable;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public toJsonObject(): JsonObject {
+		return {
+			_type: 'set-variable-event-action',
+			variable: this.variable
+		};
+	}
+}

--- a/src/store/styleguide/property/property.ts
+++ b/src/store/styleguide/property/property.ts
@@ -1,4 +1,5 @@
-import { Store } from '../../../store/store';
+import { PropertyValue } from '../../page/property-value';
+import { Store } from '../../store';
 
 /**
  * A property is the meta-information about one styleguide pattern component property
@@ -131,6 +132,16 @@ export abstract class Property {
 	 */
 	// tslint:disable-next-line:no-any
 	public convertToRender(value: any): any {
+		// tslint:disable-next-line:no-invalid-template-strings
+		if (typeof value === 'string' && value.indexOf('${') >= 0) {
+			value = value.replace(/\$\{([^\}]+)\}/, (match: string, name: string) => {
+				const variableValue: PropertyValue = Store.getInstance().getVariableValue(name);
+				return variableValue !== undefined && variableValue !== null
+					? variableValue.toString()
+					: '';
+			});
+		}
+
 		return value;
 	}
 

--- a/src/store/styleguide/slot.ts
+++ b/src/store/styleguide/slot.ts
@@ -1,4 +1,4 @@
-import { Store } from '../../store/store';
+import { Store } from '../store';
 
 /**
  * A Slot is the meta-information about one styleguide patterns supported composition points.

--- a/src/styleguide/analyzer/typescript-react-analyzer/property-analyzer.ts
+++ b/src/styleguide/analyzer/typescript-react-analyzer/property-analyzer.ts
@@ -3,6 +3,7 @@
 import { AssetProperty } from '../../../store/styleguide/property/asset-property';
 import { BooleanProperty } from '../../../store/styleguide/property/boolean-property';
 import { EnumProperty, Option } from '../../../store/styleguide/property/enum-property';
+import { EventProperty } from '../../../store/styleguide/property/event/event-property';
 import { NumberArrayProperty } from '../../../store/styleguide/property/number-array-property';
 import { NumberProperty } from '../../../store/styleguide/property/number-property';
 import { ObjectProperty } from '../../../store/styleguide/property/object-property';
@@ -26,6 +27,7 @@ type PropertyFactory = (args: PropertyFactoryArgs) => Property | undefined;
  */
 export class PropertyAnalyzer {
 	private static PROPERTY_FACTORIES: PropertyFactory[] = [
+		PropertyAnalyzer.createEventProperty,
 		PropertyAnalyzer.createBooleanProperty,
 		PropertyAnalyzer.createEnumProperty,
 		PropertyAnalyzer.createStringProperty,
@@ -182,6 +184,22 @@ export class PropertyAnalyzer {
 			const property = new EnumProperty(args.symbol.name);
 			property.setOptions(options);
 			return property;
+		}
+
+		return;
+	}
+
+	/**
+	 * Analyzes a TypeScript symbol and tries to interpret it as an event property.
+	 * On success, returns a new event property instance.
+	 * @param args The property ID to use, the TypeScript symbol, the TypeScript type, and the type
+	 * checker.
+	 * @return The Alva-supported property or undefined, if the symbol is not supported.
+	 */
+	private static createEventProperty(args: PropertyFactoryArgs): EventProperty | undefined {
+		const callSignatures: ts.Signature[] = args.type.getCallSignatures();
+		if (callSignatures.length) {
+			return new EventProperty(args.symbol.name);
 		}
 
 		return;


### PR DESCRIPTION
This PR adds a new property of type 'event', supporting the first two basic event actions:
- Set a variable from an input, and
- Go to a configured page.
The design kit already contains an example, and the two actions work, but the properties panel is lacking the UI for this new property type, so you can't yet change it in the UI.