### PR TITLE
feat: rename page elements #205

### DIFF
--- a/src/component/container/element-list.tsx
+++ b/src/component/container/element-list.tsx
@@ -169,8 +169,6 @@ export class ElementList extends React.Component<{}, ElementListState> {
 		const store = Store.getInstance();
 		const label = above(e.target, `[${ElementAnchors.label}]`);
 
-		console.log(element, label);
-
 		if (!element) {
 			return;
 		}

--- a/src/component/container/element-list.tsx
+++ b/src/component/container/element-list.tsx
@@ -34,6 +34,7 @@ const DRAG_IMG_STYLE = `
 export class ElementList extends React.Component<{}, ElementListState> {
 	private dragImg?: HTMLElement;
 	private globalKeyUpListener?: (e: KeyboardEvent) => void;
+	private ref: HTMLElement | null;
 
 	public state = {
 		dragging: true
@@ -253,6 +254,15 @@ export class ElementList extends React.Component<{}, ElementListState> {
 
 	private handleKeyUp(e: KeyboardEvent): void {
 		const store = Store.getInstance();
+		const node = e.target as Node;
+		const contains = (target: Node) => (this.ref ? this.ref.contains(target) : false);
+
+		// Only handle key events if either
+		// (1) it is global, thus fires on body
+		// (2) is a node inside the page element list
+		if (e.target !== document.body && !contains(node)) {
+			return;
+		}
 
 		if (e.keyCode === 13) {
 			// ENTER
@@ -307,6 +317,7 @@ export class ElementList extends React.Component<{}, ElementListState> {
 				onKeyUp={e => this.handleKeyUp(e.nativeEvent)}
 				onMouseLeave={e => this.handleMouseLeave(e)}
 				onMouseOver={e => this.handleMouseOver(e)}
+				ref={ref => (this.ref = ref)}
 			>
 				<ElementTree {...item} dragging={this.state.dragging} />
 			</div>

--- a/src/component/container/element-wrapper.tsx
+++ b/src/component/container/element-wrapper.tsx
@@ -10,6 +10,7 @@ export interface ElementWrapperState {
 
 export interface ElementWrapperProps {
 	active?: boolean;
+	draggable: boolean;
 	dragging: boolean;
 	editable?: boolean;
 	id: string;
@@ -109,7 +110,7 @@ export class ElementWrapper extends React.Component<ElementWrapperProps, Element
 			<Element
 				active={active}
 				dragging={this.props.dragging}
-				draggable
+				draggable={this.props.draggable}
 				editable={this.props.editable}
 				onChange={e => this.handleChange(e)}
 				onClick={e => this.handleClick(e)}

--- a/src/component/container/element-wrapper.tsx
+++ b/src/component/container/element-wrapper.tsx
@@ -1,4 +1,4 @@
-import Element from '../../lsg/patterns/element';
+import Element, { ElementAnchors } from '../../lsg/patterns/element';
 import * as React from 'react';
 
 export interface ElementWrapperState {
@@ -29,7 +29,7 @@ export class ElementWrapper extends React.Component<ElementWrapperProps, Element
 
 	private handleClick(e: React.MouseEvent<HTMLElement>): void {
 		const target = e.target as HTMLElement;
-		const icon = above(target, 'svg[data-icon]');
+		const icon = above(target, `svg[${ElementAnchors.icon}]`);
 
 		if (icon) {
 			e.stopPropagation();

--- a/src/component/container/element-wrapper.tsx
+++ b/src/component/container/element-wrapper.tsx
@@ -1,5 +1,6 @@
 import Element, { ElementAnchors } from '../../lsg/patterns/element';
 import * as React from 'react';
+import { Store } from '../../store/store';
 
 export interface ElementWrapperState {
 	highlight?: boolean;
@@ -10,6 +11,7 @@ export interface ElementWrapperState {
 export interface ElementWrapperProps {
 	active?: boolean;
 	dragging: boolean;
+	editable?: boolean;
 	id: string;
 	onClick?: React.MouseEventHandler<HTMLElement>;
 	onContextMenu?: React.MouseEventHandler<HTMLElement>;
@@ -24,8 +26,19 @@ export class ElementWrapper extends React.Component<ElementWrapperProps, Element
 	public state = {
 		open: this.props.open,
 		highlightPlaceholder: false,
-		highlight: false
+		highlight: false,
+		editTitle: this.props.title
 	};
+
+	private handleChange(e: React.FormEvent<HTMLInputElement>): void {
+		const target = e.target as HTMLInputElement;
+		const store = Store.getInstance();
+		const element = store.getNameEditableElement();
+
+		if (element) {
+			element.setName(target.value);
+		}
+	}
 
 	private handleClick(e: React.MouseEvent<HTMLElement>): void {
 		const target = e.target as HTMLElement;
@@ -97,6 +110,8 @@ export class ElementWrapper extends React.Component<ElementWrapperProps, Element
 				active={active}
 				dragging={this.props.dragging}
 				draggable
+				editable={this.props.editable}
+				onChange={e => this.handleChange(e)}
 				onClick={e => this.handleClick(e)}
 				onDragDrop={e => this.handleDragDrop(e)}
 				onDragDropForChild={e => this.handleDragDropForChild(e)}

--- a/src/lsg/patterns/element/index.tsx
+++ b/src/lsg/patterns/element/index.tsx
@@ -123,12 +123,6 @@ const StyledElementLabel = styled(div)`
 			: ''};
 `;
 
-const LabelContent = styled.div`
-	box-sizing: border-box;
-	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px
-		${getSpace(Size.XXL)}px;
-`;
-
 const placeholderDiv = tag('div').omit(['highlightPlaceholder']);
 const StyledPlaceholder = styled(placeholderDiv)`
 	position: relative;
@@ -201,6 +195,13 @@ const StyledIcon = styled(Icon)`
 	${(props: StyledIconProps) => (props.active ? `fill: ${colors.blue20.toString()}` : '')};
 `;
 
+const LabelContent = styled.div`
+	box-sizing: border-box;
+	width: 100%;
+	margin-left: ${getSpace(Size.XXL) - 3}px;
+	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px 3px;
+`;
+
 const StyledSeamlessInput = styled.input`
 	box-sizing: border-box;
 	width: 100%;
@@ -264,7 +265,6 @@ const Element: React.StatelessComponent<ElementProps> = props => (
 			/>
 		)}
 		<StyledElementLabel
-			{...{ [ElementAnchors.label]: true }}
 			active={props.active}
 			highlight={props.highlight}
 			onContextMenu={props.onContextMenu}
@@ -287,9 +287,15 @@ const Element: React.StatelessComponent<ElementProps> = props => (
 					/>
 				)}
 			{props.editable ? (
-				<SeamlessInput value={props.title} onChange={props.onChange} autoFocus autoSelect />
+				<SeamlessInput
+					{...{ [ElementAnchors.label]: true }}
+					value={props.title}
+					onChange={props.onChange}
+					autoFocus
+					autoSelect
+				/>
 			) : (
-				<LabelContent>{props.title}</LabelContent>
+				<LabelContent {...{ [ElementAnchors.label]: true }}>{props.title}</LabelContent>
 			)}
 		</StyledElementLabel>
 		{props.children && (

--- a/src/lsg/patterns/element/index.tsx
+++ b/src/lsg/patterns/element/index.tsx
@@ -5,6 +5,13 @@ import { getSpace, Size } from '../space';
 import styled from 'styled-components';
 import { tag } from '../tag';
 
+export const ElementAnchors = {
+	element: 'data-element-id',
+	icon: 'data-icon',
+	label: 'data-element-label',
+	placeholder: 'data-element-placeholder'
+};
+
 export interface ElementProps {
 	active?: boolean;
 	draggable?: boolean;
@@ -190,10 +197,14 @@ const StyledIcon = styled(Icon)`
 `;
 
 const Element: React.StatelessComponent<ElementProps> = props => (
-	<StyledElement draggable={props.draggable} data-id={props.id} onClick={props.onClick}>
+	<StyledElement
+		{...{ [ElementAnchors.element]: props.id }}
+		draggable={props.draggable}
+		onClick={props.onClick}
+	>
 		{props.dragging && (
 			<StyledPlaceholder
-				data-element-placeholder
+				{...{ [ElementAnchors.placeholder]: true }}
 				highlightPlaceholder={props.highlightPlaceholder}
 				onDragOver={(e: React.DragEvent<HTMLElement>) => {
 					e.preventDefault();
@@ -204,7 +215,7 @@ const Element: React.StatelessComponent<ElementProps> = props => (
 			/>
 		)}
 		<StyledElementLabel
-			data-element-label
+			{...{ [ElementAnchors.label]: true }}
 			active={props.active}
 			highlight={props.highlight}
 			onContextMenu={props.onContextMenu}

--- a/src/lsg/patterns/element/index.tsx
+++ b/src/lsg/patterns/element/index.tsx
@@ -16,9 +16,11 @@ export interface ElementProps {
 	active?: boolean;
 	draggable?: boolean;
 	dragging: boolean;
+	editable?: boolean;
 	highlight?: boolean;
 	highlightPlaceholder?: boolean;
 	id?: string;
+	onChange?: React.FormEventHandler<HTMLInputElement>;
 	onClick?: React.MouseEventHandler<HTMLElement>;
 	onContextMenu?: React.MouseEventHandler<HTMLElement>;
 	onDragDrop?: React.DragEventHandler<HTMLElement>;
@@ -64,9 +66,6 @@ const div = tag('div').omit(['active', 'highlight']);
 const StyledElementLabel = styled(div)`
 	position: relative;
 	display: flex;
-	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px ${getSpace(
-	Size.XXL
-)}px;
 	align-items: center;
 	color: ${colors.grey20.toString()};
 	position: relative;
@@ -122,6 +121,26 @@ const StyledElementLabel = styled(div)`
 			}
 		`
 			: ''};
+`;
+
+const SeamlessInput = styled.input`
+	box-sizing: border-box;
+	width: 100%;
+	color: ${colors.grey20.toString()};
+	font-size: inherit;
+	line-height: inherit;
+	padding: ${getSpace(Size.XS - 1)}px ${getSpace(Size.L - 1)}px ${getSpace(Size.XS - 1)}px 3px;
+	margin: 1px 1px 1px ${getSpace(Size.XXL - 3)}px;
+	border: 0;
+	&:focus {
+		outline: none;
+	}
+`;
+
+const LabelContent = styled.div`
+	box-sizing: border-box;
+	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px
+		${getSpace(Size.XXL)}px;
 `;
 
 const placeholderDiv = tag('div').omit(['highlightPlaceholder']);
@@ -237,7 +256,11 @@ const Element: React.StatelessComponent<ElementProps> = props => (
 						active={props.active}
 					/>
 				)}
-			<div>{props.title}</div>
+			{props.editable ? (
+				<SeamlessInput value={props.title} onChange={props.onChange} autoFocus />
+			) : (
+				<LabelContent>{props.title}</LabelContent>
+			)}
 		</StyledElementLabel>
 		{props.children && (
 			<StyledElementChild open={props.open}>{props.children}</StyledElementChild>

--- a/src/lsg/patterns/element/index.tsx
+++ b/src/lsg/patterns/element/index.tsx
@@ -197,9 +197,12 @@ const StyledIcon = styled(Icon)`
 
 const LabelContent = styled.div`
 	box-sizing: border-box;
-	width: 100%;
 	margin-left: ${getSpace(Size.XXL) - 3}px;
+	overflow: hidden;
 	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px 3px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
 `;
 
 const StyledSeamlessInput = styled.input`

--- a/src/lsg/patterns/element/index.tsx
+++ b/src/lsg/patterns/element/index.tsx
@@ -123,20 +123,6 @@ const StyledElementLabel = styled(div)`
 			: ''};
 `;
 
-const SeamlessInput = styled.input`
-	box-sizing: border-box;
-	width: 100%;
-	color: ${colors.grey20.toString()};
-	font-size: inherit;
-	line-height: inherit;
-	padding: ${getSpace(Size.XS - 1)}px ${getSpace(Size.L - 1)}px ${getSpace(Size.XS - 1)}px 3px;
-	margin: 1px 1px 1px ${getSpace(Size.XXL - 3)}px;
-	border: 0;
-	&:focus {
-		outline: none;
-	}
-`;
-
 const LabelContent = styled.div`
 	box-sizing: border-box;
 	padding: ${getSpace(Size.XS)}px ${getSpace(Size.L)}px ${getSpace(Size.XS)}px
@@ -215,6 +201,50 @@ const StyledIcon = styled(Icon)`
 	${(props: StyledIconProps) => (props.active ? `fill: ${colors.blue20.toString()}` : '')};
 `;
 
+const StyledSeamlessInput = styled.input`
+	box-sizing: border-box;
+	width: 100%;
+	color: ${colors.grey20.toString()};
+	font-size: inherit;
+	line-height: inherit;
+	padding: ${getSpace(Size.XS - 1)}px ${getSpace(Size.L - 1)}px ${getSpace(Size.XS - 1)}px 3px;
+	margin: 1px 1px 1px ${getSpace(Size.XXL - 3)}px;
+	border: 0;
+	&:focus {
+		outline: none;
+	}
+`;
+
+interface SeamlessInputProps {
+	autoFocus?: boolean;
+	autoSelect?: boolean;
+	onChange?: React.FormEventHandler<HTMLInputElement>;
+	value: string;
+}
+
+class SeamlessInput extends React.Component<SeamlessInputProps> {
+	private ref: HTMLInputElement | null = null;
+
+	public componentDidMount(): void {
+		if (this.ref !== null && this.props.autoSelect && this.props.autoFocus) {
+			const ref = this.ref as HTMLInputElement;
+			ref.setSelectionRange(0, this.props.value.length);
+		}
+	}
+
+	public render(): JSX.Element {
+		const { props } = this;
+		return (
+			<StyledSeamlessInput
+				autoFocus={props.autoFocus}
+				innerRef={ref => (this.ref = ref)}
+				value={props.value}
+				onChange={props.onChange}
+			/>
+		);
+	}
+}
+
 const Element: React.StatelessComponent<ElementProps> = props => (
 	<StyledElement
 		{...{ [ElementAnchors.element]: props.id }}
@@ -257,7 +287,7 @@ const Element: React.StatelessComponent<ElementProps> = props => (
 					/>
 				)}
 			{props.editable ? (
-				<SeamlessInput value={props.title} onChange={props.onChange} autoFocus />
+				<SeamlessInput value={props.title} onChange={props.onChange} autoFocus autoSelect />
 			) : (
 				<LabelContent>{props.title}</LabelContent>
 			)}

--- a/src/store/command/element-location-command.ts
+++ b/src/store/command/element-location-command.ts
@@ -194,6 +194,11 @@ export class ElementLocationCommand extends ElementCommand {
 			return false;
 		}
 
+		// Do not try to add an element to itself
+		if (this.element === this.parent) {
+			return false;
+		}
+
 		this.element.setParent(this.parent, this.slotId, this.index);
 		this.memorizeElementIds();
 

--- a/src/store/command/element-location-command.ts
+++ b/src/store/command/element-location-command.ts
@@ -66,7 +66,7 @@ export class ElementLocationCommand extends ElementCommand {
 
 		this.previousParent = element.getParent();
 		this.previousSlotId = element.getParentSlotId();
-		this.previousIndex = this.previousParent ? element.getIndex() : undefined;
+		this.previousIndex = this.previousParent ? (element.getIndex() as number) : undefined;
 
 		// Memorize the page IDs of the new parent, if the element has no parent.
 		// This way, closing and opening a page does not break the command.
@@ -121,7 +121,7 @@ export class ElementLocationCommand extends ElementCommand {
 			newSibling,
 			parent,
 			location.getParentSlotId(),
-			parent ? location.getIndex() + 1 : undefined
+			parent ? (location.getIndex() as number) + 1 : undefined
 		);
 	}
 

--- a/src/store/command/element-name-command.ts
+++ b/src/store/command/element-name-command.ts
@@ -25,7 +25,7 @@ export class ElementNameCommand extends ElementCommand {
 	public constructor(element: PageElement, name: string) {
 		super(element);
 
-		this.name = name;
+		this.name = name.length === 0 ? element.getName({ unedited: true }) : name;
 		this.previousName = element.getName({ unedited: true });
 
 		if (!this.pageId) {

--- a/src/store/command/element-name-command.ts
+++ b/src/store/command/element-name-command.ts
@@ -26,7 +26,7 @@ export class ElementNameCommand extends ElementCommand {
 		super(element);
 
 		this.name = name;
-		this.previousName = element.getName();
+		this.previousName = element.getName({ unedited: true });
 
 		if (!this.pageId) {
 			throw new Error(

--- a/src/store/page/page-element.ts
+++ b/src/store/page/page-element.ts
@@ -30,6 +30,11 @@ export class PageElement {
 	@MobX.observable private contents: Map<string, PageElement[]> = new Map();
 
 	/**
+	 * The currently edited name of the page element, to be commited
+	 */
+	@MobX.observable private editedName: string;
+
+	/**
 	 * The technical (internal) ID of the page element.
 	 */
 	@MobX.observable private id: string;
@@ -38,6 +43,11 @@ export class PageElement {
 	 * The assigned name of the page element, initially the pattern's human-friendly name.
 	 */
 	@MobX.observable private name: string;
+
+	/**
+	 * Wether the element name is editable
+	 */
+	@MobX.observable private nameEditable: boolean;
 
 	/**
 	 * The page this element belongs to.
@@ -88,6 +98,7 @@ export class PageElement {
 		this.pattern = properties.pattern;
 		this.patternId = this.pattern ? this.pattern.getId() : undefined;
 		this.parentSlotId = properties.parentSlotId;
+		this.nameEditable = false;
 
 		if (this.name === undefined && this.pattern) {
 			this.name = this.pattern.getName();
@@ -253,8 +264,20 @@ export class PageElement {
 	 * Returns the assigned name of the page element, initially the pattern's human-friendly name.
 	 * @return The assigned name of the page element.
 	 */
-	public getName(): string {
+	public getName(opts?: { unedited: boolean }): string {
+		if ((!opts || !opts.unedited) && this.nameEditable) {
+			return this.editedName;
+		}
+
 		return this.name;
+	}
+
+	/**
+	 * Returns the editable state of the element's name
+	 * @return The editable state
+	 */
+	public getNameEditable(): boolean {
+		return this.nameEditable;
 	}
 
 	/**
@@ -402,7 +425,25 @@ export class PageElement {
 	 * @param name The assigned name of the page element.
 	 */
 	public setName(name: string): void {
-		this.name = name;
+		if (this.nameEditable) {
+			this.editedName = name;
+		} else {
+			this.name = name;
+		}
+	}
+
+	/**
+	 * Sets the editable state of the element's name
+	 * @param nameEditable Wether the name is editable
+	 */
+	public setNameEditable(nameEditable: boolean): void {
+		if (nameEditable) {
+			this.editedName = this.name;
+		} else {
+			this.name = this.editedName || this.name;
+		}
+
+		this.nameEditable = nameEditable;
 	}
 
 	/**

--- a/src/store/page/page-element.ts
+++ b/src/store/page/page-element.ts
@@ -242,9 +242,9 @@ export class PageElement {
 	 * Returns the 0-based position of this element within its parent slot.
 	 * @return The 0-based position of this element.
 	 */
-	public getIndex(): number {
+	public getIndex(): number | undefined {
 		if (!this.parent) {
-			throw new Error('This element has no parent');
+			return undefined;
 		}
 		return this.parent.getSlotContents(this.parentSlotId).indexOf(this);
 	}

--- a/src/store/page/page-element.ts
+++ b/src/store/page/page-element.ts
@@ -273,14 +273,6 @@ export class PageElement {
 	}
 
 	/**
-	 * Returns the editable state of the element's name
-	 * @return The editable state
-	 */
-	public getNameEditable(): boolean {
-		return this.nameEditable;
-	}
-
-	/**
 	 * Returns the page this element belongs to.
 	 * @return The page this element belongs to.
 	 */
@@ -376,6 +368,14 @@ export class PageElement {
 	 */
 	public isDescendentOf(parent?: PageElement): boolean {
 		return parent ? parent.isAncestorOf(this) : false;
+	}
+
+	/**
+	 * Returns the editable state of the element's name
+	 * @return The editable state
+	 */
+	public isNameEditable(): boolean {
+		return this.nameEditable;
 	}
 
 	/**

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -69,6 +69,11 @@ export class Store {
 	@MobX.observable private elementFocussed?: boolean = false;
 
 	/**
+	 * The currently name-editable element in the element list.
+	 */
+	@MobX.observable private nameEditableElement?: PageElement;
+
+	/**
 	 * The current search term in the patterns list, or an empty string if there is none.
 	 */
 	@MobX.observable private patternSearchTerm: string = '';
@@ -343,6 +348,10 @@ export class Store {
 	 */
 	public getDraggedElement(): PageElement | undefined {
 		return this.draggedElement;
+	}
+
+	public getNameEditableElement(): PageElement | undefined {
+		return this.nameEditableElement;
 	}
 
 	/**
@@ -827,6 +836,18 @@ export class Store {
 		this.elementFocussed = elementFocussed;
 	}
 
+	public setNameEditableElement(editableElement?: PageElement): void {
+		if (this.nameEditableElement && this.nameEditableElement !== editableElement) {
+			this.nameEditableElement.setNameEditable(false);
+		}
+
+		if (editableElement) {
+			editableElement.setNameEditable(true);
+		}
+
+		this.nameEditableElement = editableElement;
+	}
+
 	/**
 	 * Loads a given JSON object into the store as current page.
 	 * Used internally within the store, do not use from UI components.
@@ -866,6 +887,9 @@ export class Store {
 	 * @see setElementFocussed
 	 */
 	public setSelectedElement(selectedElement?: PageElement): void {
+		if (this.selectedElement && this.selectedElement !== selectedElement) {
+			this.setNameEditableElement();
+		}
 		this.rightPane = null;
 		this.selectedElement = selectedElement;
 		this.selectedSlotId = undefined;


### PR DESCRIPTION
This implements an edit mode for page elements in the tree view. 

## Start edit mode

* Click on the label of a selected item
* Hit enter when an item is selected

## Exit edit mode 

* Blur the element
* Select another element
* Hit enter

<details>
<summary>Screencast</summary>

![name-element](https://user-images.githubusercontent.com/4248851/39599519-59ee189a-4f1c-11e8-924b-746846b2d6a7.gif)
</details>

Fixes #205 