### PR TITLE
feat: add floating-button component

### DIFF
--- a/src/lsg/patterns/floating-button/demo.tsx
+++ b/src/lsg/patterns/floating-button/demo.tsx
@@ -1,0 +1,16 @@
+import DemoContainer from '../demo-container';
+import { Icon, IconName, IconRegistry } from '../icons';
+import * as React from 'react';
+import { SpaceSize } from '../space';
+import { FloatingButton } from '.';
+
+const FloatingButtonDemo: React.StatelessComponent<void> = (): JSX.Element => (
+	<DemoContainer>
+		<div style={{ width: SpaceSize.XXXL }}>
+			<FloatingButton icon={<Icon name={IconName.Robo} />} />
+		</div>
+		<IconRegistry names={IconName} />
+	</DemoContainer>
+);
+
+export default FloatingButtonDemo;

--- a/src/lsg/patterns/floating-button/index.md
+++ b/src/lsg/patterns/floating-button/index.md
@@ -1,0 +1,12 @@
+[Floating Action Button](https://material.io/guidelines/components/buttons-floating-action-button.html) commonly found in Material Design.
+
+The Alva implemation limits the content to instances of [Icon](./pattern/icons).
+
+* Minimal width is 56px
+* Height directly proportional to width `1:1`
+* Centers provided [Icon](./pattern/icons) horizontally and vertically
+* Positioning is static
+
+## Usage in Alva
+
+* Primary action on page list view for adding new pages

--- a/src/lsg/patterns/floating-button/index.tsx
+++ b/src/lsg/patterns/floating-button/index.tsx
@@ -1,0 +1,55 @@
+import { colors } from '../colors';
+import * as React from 'react';
+import styled from 'styled-components';
+
+export interface ButtonProps {
+	icon: React.ReactNode;
+	onClick?: React.MouseEventHandler<HTMLElement>;
+}
+
+const StyledFloatingButton = styled.button`
+	background: transparent;
+	border: none;
+	box-sizing: border-box;
+	color: ${colors.white.toString()};
+	cursor: pointer;
+	margin: 0;
+	min-width: 56px;
+	overflow: hidden;
+	padding: 0;
+	position: relative;
+	&::before {
+		content: '';
+		display: block;
+		padding-top: 100%;
+		background: ${colors.blue.toString()};
+		border-radius: 50%;
+	}
+	&:hover {
+		&::before {
+			content: '';
+			display: block;
+			padding-top: 100%;
+			background: ${colors.blue20.toString()};
+			border-radius: 50%;
+		}
+	}
+`;
+
+const StyledFloatingButtonContent = styled.div`
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+`;
+
+export const FloatingButton: React.SFC<ButtonProps> = props => (
+	<StyledFloatingButton onClick={props.onClick}>
+		<StyledFloatingButtonContent>{props.icon}</StyledFloatingButtonContent>
+	</StyledFloatingButton>
+);

--- a/src/lsg/patterns/floating-button/pattern.json
+++ b/src/lsg/patterns/floating-button/pattern.json
@@ -1,0 +1,7 @@
+{
+	"name": "floating-button",
+	"displayName": "Floating Button",
+	"version": "1.0.0",
+	"tags": ["atom", "button"],
+	"flag": "alpha"
+}

--- a/src/lsg/patterns/icons/demo.tsx
+++ b/src/lsg/patterns/icons/demo.tsx
@@ -1,5 +1,5 @@
 import DemoContainer from '../demo-container';
-import { Icon, IconName, IconRegistry, reduce, IconSize } from './index';
+import { Icon, IconName, IconRegistry, IconSize, reduce } from './index';
 import * as React from 'react';
 import styled from 'styled-components';
 

--- a/src/lsg/patterns/icons/index.tsx
+++ b/src/lsg/patterns/icons/index.tsx
@@ -8,6 +8,7 @@ export enum IconName {
 	ArrowFillRight,
 	ArrowFillLeft,
 	Robo,
+	Plus,
 	Pattern
 }
 export interface IconRegistryProps {
@@ -60,6 +61,14 @@ const icons: { readonly [key: string]: JSX.Element[][] | JSX.Element[] } = {
 	[IconName.ArrowFillLeft]: [[<path key="arrowFillLeft" d="M16 20l-8-8 8-8v16z" />]],
 	[IconName.Robo]: [
 		[<path key="robo" d="M0 0h24v24H0V0zm15 5v5h5V5h-5zM4 20h16v-1H4v1zM4 5v5h5V5H4z" />]
+	],
+	[IconName.Plus]: [
+		[
+			<path
+				key="plus"
+				d="M11,11 L11,2 L13,2 L13,11 L22,11 L22,13 L13,13 L13,22 L11,22 L11,13 L2,13 L2,11 L11,11 Z"
+			/>
+		]
 	],
 	[IconName.Pattern]: [
 		[


### PR DESCRIPTION
This implements a floating button component commonly found in Material Design. 

Prepares a bigger PR that implements UI to add new pages (#24). 