### PR TITLE
feat: allow users to add new pages

### DIFF
--- a/src/component/page-list/page-add-button.tsx
+++ b/src/component/page-list/page-add-button.tsx
@@ -1,0 +1,34 @@
+import { FloatingButton } from '../../lsg/patterns/floating-button';
+import { Icon, IconName } from '../../lsg/patterns/icons';
+import { EditState } from '../../store/page/page-ref';
+import * as React from 'react';
+import Space, { SpaceSize } from '../../lsg/patterns/space';
+import { Store } from '../../store/store';
+import styled from 'styled-components';
+
+export class PageAddButton extends React.Component {
+	private handleClick(e: React.MouseEvent<HTMLElement>): void {
+		e.preventDefault();
+		const store = Store.getInstance();
+		const page = store.addNewPageRef();
+		store.openPage(page.getId());
+		page.setNameState(EditState.Editing);
+	}
+
+	public render(): JSX.Element {
+		return (
+			<FixedContainer>
+				<FloatingButton
+					icon={<Icon name={IconName.Plus} />}
+					onClick={e => this.handleClick(e)}
+				/>
+			</FixedContainer>
+		);
+	}
+}
+
+const FixedContainer = styled(Space)`
+	position: fixed;
+	bottom: ${SpaceSize.XXL}px;
+	right: ${SpaceSize.XXXL}px;
+`;

--- a/src/component/page-list/page-list-container.tsx
+++ b/src/component/page-list/page-list-container.tsx
@@ -1,5 +1,6 @@
 import Layout, { LayoutWrap } from '../../lsg/patterns/layout';
 import { observer } from 'mobx-react';
+import { PageAddButton } from './page-add-button';
 import { PageRef } from '../../store/page/page-ref';
 import { PageTileContainer } from './page-tile-container';
 import * as React from 'react';
@@ -28,6 +29,7 @@ export const PageListContainer: React.StatelessComponent = observer((): JSX.Elem
 							page={pageRef}
 						/>
 					))}
+				<PageAddButton />
 			</Layout>
 		</Space>
 	);

--- a/src/component/page-list/page-list-preview.tsx
+++ b/src/component/page-list/page-list-preview.tsx
@@ -5,6 +5,7 @@ import Copy from '../../lsg/patterns/copy';
 import { Headline } from '../../lsg/patterns/headline';
 import Space, { SpaceSize } from '../../lsg/patterns/space';
 import { Store } from '../../store/store';
+import styled from 'styled-components';
 
 export const PageListPreview: React.StatelessComponent = props => {
 	const project = Store.getInstance().getCurrentProject();
@@ -13,16 +14,25 @@ export const PageListPreview: React.StatelessComponent = props => {
 	}
 	const dateString = new Intl.DateTimeFormat().format(project.getLastChangedDate());
 	return (
-		<Space size={[SpaceSize.XXL * 3]}>
-			<Space size={[SpaceSize.S, SpaceSize.S, SpaceSize.XXXL]}>
-				<Headline order={1} tagName="h1" textColor={colors.grey20}>
-					{project.getName()}
-				</Headline>
-				<Copy textColor={colors.grey60}>
-					Last change: {dateString} by {project.getLastChangedAuthor()}
-				</Copy>
+		<StyledPageListPreview>
+			<Space size={[SpaceSize.XXL * 3]}>
+				<Space size={[SpaceSize.S, SpaceSize.S, SpaceSize.XXXL]}>
+					<Headline order={1} tagName="h1" textColor={colors.grey20}>
+						{project.getName()}
+					</Headline>
+					<Copy textColor={colors.grey60}>
+						Last change: {dateString} by {project.getLastChangedAuthor()}
+					</Copy>
+				</Space>
+				{props.children}
 			</Space>
-			{props.children}
-		</Space>
+		</StyledPageListPreview>
 	);
 };
+
+const StyledPageListPreview = styled.div`
+	box-sizing: border-box;
+	overflow: auto;
+	width: 100%;
+	min-height: 100vh;
+`;

--- a/src/lsg/patterns/floating-button/index.tsx
+++ b/src/lsg/patterns/floating-button/index.tsx
@@ -25,6 +25,9 @@ const StyledFloatingButton = styled.button`
 		background: ${colors.blue.toString()};
 		border-radius: 50%;
 	}
+	&:focus {
+		outline: none;
+	}
 	&:hover {
 		&::before {
 			content: '';

--- a/src/lsg/patterns/preview-tile/demo.tsx
+++ b/src/lsg/patterns/preview-tile/demo.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import Copy from '../copy';
 import { Headline } from '../headline';
-import { PreviewTile } from './index';
 import Layout from '../layout';
 import Space, { SpaceSize } from '../space';
+import { EditState, PreviewTile } from '.';
 
 const handleChange = (e: React.ChangeEvent<HTMLInputElement>): string => e.target.value;
 
@@ -21,47 +21,42 @@ export const DemoPreviewTile = (): JSX.Element => (
 		<Layout>
 			<Space size={SpaceSize.S}>
 				<PreviewTile
-					editable={false}
 					focused={false}
 					onChange={handleChange}
-					named={true}
-					value="Editable"
+					name="Editable"
+					nameState={EditState.Editable}
 				/>
 			</Space>
 			<Space size={SpaceSize.S}>
 				<PreviewTile
-					editable={false}
 					focused={true}
 					onChange={handleChange}
-					named={true}
-					value="Page Name"
+					name="Page Name"
+					nameState={EditState.Editable}
 				/>
 			</Space>
 			<Space size={SpaceSize.S}>
 				<PreviewTile
-					editable={true}
 					focused={true}
 					onChange={handleChange}
-					named={true}
-					value="Editable Page Name"
+					name="Editable Page Name"
+					nameState={EditState.Editable}
 				/>
 			</Space>
 			<Space size={SpaceSize.S}>
 				<PreviewTile
-					editable={false}
 					focused={false}
 					onChange={handleChange}
-					named={true}
-					value="Editable Page Name"
+					name="Editable Page Name"
+					nameState={EditState.Editable}
 				/>
 			</Space>
 			<Space size={SpaceSize.S}>
 				<PreviewTile
-					editable={false}
 					focused={false}
 					onChange={handleChange}
-					named={true}
-					value="Editable Page Name"
+					name="Editable Page Name"
+					nameState={EditState.Editable}
 				/>
 			</Space>
 		</Layout>

--- a/src/lsg/patterns/preview-tile/index.tsx
+++ b/src/lsg/patterns/preview-tile/index.tsx
@@ -5,18 +5,22 @@ import * as ReactDOM from 'react-dom';
 import { getSpace, SpaceSize } from '../space';
 import styled from 'styled-components';
 
+export enum EditState {
+	Editable = 'Editable',
+	Editing = 'Editing'
+}
+
 export interface PreviewTileProps {
-	editable: boolean;
 	focused: boolean;
 	id?: string;
-	named: boolean;
+	name: string;
+	nameState: EditState;
 	onBlur?: React.FocusEventHandler<HTMLInputElement>;
 	onChange?: React.ChangeEventHandler<HTMLInputElement>;
 	onClick?: React.MouseEventHandler<HTMLElement>;
 	onDoubleClick?: React.MouseEventHandler<HTMLElement>;
 	onFocus?: React.FocusEventHandler<HTMLInputElement>;
 	onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
-	value: string;
 }
 
 interface EditableTitleProps {
@@ -38,8 +42,7 @@ interface StyledPreviewTileProps {
 
 interface StyledPreviewTitleProps {
 	children: React.ReactNode;
-	focusable: boolean;
-	named: boolean;
+	editable: boolean;
 }
 
 const StyledPreview = styled.section`
@@ -67,8 +70,7 @@ const StyledTitle = (props: StyledPreviewTitleProps): JSX.Element => {
 		font-size: 12px;
 		font-weight: normal;
 		text-align: center;
-		color: ${props.named ? colors.black.toString() : colors.grey80.toString()};
-		cursor: ${props.focusable ? 'text' : 'default'};
+		cursor: ${props.editable ? 'text' : 'default'};
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -132,22 +134,20 @@ class EditableTitle extends React.Component<EditableTitleProps> {
 
 export const PreviewTile: React.StatelessComponent<PreviewTileProps> = (props): JSX.Element => (
 	<StyledPreview data-id={props.id} onClick={props.onClick} onDoubleClick={props.onDoubleClick}>
-		{props.editable ? (
+		{props.nameState === EditState.Editing ? (
 			<EditableTitle
-				autoFocus={props.editable}
-				autoSelect={props.editable}
+				autoFocus
+				autoSelect
 				data-title={true}
 				focused={props.focused}
 				onBlur={props.onBlur}
 				onChange={props.onChange}
 				onFocus={props.onFocus}
 				onKeyDown={props.onKeyDown}
-				value={props.value}
+				value={props.name}
 			/>
 		) : (
-			<StyledTitle focusable={props.focused} named={props.named}>
-				{props.value}
-			</StyledTitle>
+			<StyledTitle editable={props.focused}>{props.name}</StyledTitle>
 		)}
 		<StyledPreviewTile focused={props.focused} />
 	</StyledPreview>

--- a/src/store/page/page-ref.ts
+++ b/src/store/page/page-ref.ts
@@ -1,8 +1,16 @@
-import { JsonObject } from '../json';
+import * as Fs from 'fs';
+import { JsonObject, Persister } from '../json';
 import * as MobX from 'mobx';
+import { Page } from './page';
+import * as Path from 'path';
 import { Project } from '../project';
 import { Store } from '../store';
 import * as Uuid from 'uuid';
+
+export enum EditState {
+	Editable = 'Editable',
+	Editing = 'Editing'
+}
 
 export interface PageRefProperties {
 	id?: string;
@@ -21,6 +29,11 @@ export interface PageRefProperties {
  */
 export class PageRef {
 	/**
+	 * Intermediary edited name
+	 */
+	@MobX.observable public editedName: string = '';
+
+	/**
 	 * The technical (internal) ID of the page.
 	 */
 	@MobX.observable private id: string;
@@ -37,6 +50,11 @@ export class PageRef {
 	 * In the frontend, to be displayed instead of the ID.
 	 */
 	@MobX.observable private name: string;
+
+	/**
+	 * Wether the name may be edited
+	 */
+	@MobX.observable public nameState: EditState = EditState.Editable;
 
 	/**
 	 * The path of the page file, relative to the alva.yaml.
@@ -94,6 +112,10 @@ export class PageRef {
 		}
 	}
 
+	public getEditedName(): string {
+		return this.editedName;
+	}
+
 	/**
 	 * Returns the technical (internal) ID of the page.
 	 * @return The technical (internal) ID of the page.
@@ -117,8 +139,16 @@ export class PageRef {
 	 * In the frontend, to be displayed instead of the ID.
 	 * @return The human-friendly name of the page.
 	 */
-	public getName(): string {
+	public getName(options?: { unedited: boolean }): string {
+		if ((!options || !options.unedited) && this.nameState === EditState.Editing) {
+			return this.editedName;
+		}
+
 		return this.name;
+	}
+
+	public getNameState(): EditState {
+		return this.nameState;
 	}
 
 	/**
@@ -141,8 +171,22 @@ export class PageRef {
 	 * Sets the human-friendly name of the page.
 	 * @param name The human-friendly name of the page.
 	 */
+	@MobX.action
 	public setName(name: string): void {
+		if (this.nameState === EditState.Editing) {
+			this.editedName = name;
+			return;
+		}
+
 		this.name = name;
+	}
+
+	public setNameState(state: EditState): void {
+		if (state === EditState.Editing) {
+			this.editedName = this.name;
+		}
+
+		this.nameState = state;
 	}
 
 	/**
@@ -180,6 +224,20 @@ export class PageRef {
 			name: this.name,
 			path: this.path
 		};
+	}
+
+	/**
+	 * Create the persistence file for this page ref if it does not exist
+	 */
+	public touch(): void {
+		const store = Store.getInstance();
+		const path = Path.resolve(store.getPagesPath(), this.path);
+
+		if (!Fs.existsSync(path)) {
+			const page = Page.fromJsonObject({}, this.id);
+			Persister.saveYaml(path, page.toJsonObject());
+			this.updateLastPersistedPath();
+		}
 	}
 
 	/**

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -195,6 +195,24 @@ export class Store {
 		return guessedName.substring(0, 1).toUpperCase() + guessedName.substring(1);
 	}
 
+	public addNewPageRef(): PageRef {
+		const project = this.currentProject as Project;
+
+		// Page refs register with their project automatically
+		// via side effects
+		const pageRef = new PageRef({
+			name: 'New page',
+			project
+		});
+
+		pageRef.setPath(this.findAvailablePagePath(pageRef));
+		pageRef.updateLastPersistedPath();
+
+		pageRef.touch();
+
+		return pageRef;
+	}
+
 	/**
 	 * Add a new project definition to the list of projects.
 	 * Note: Changes to the projects and page references are saved only when calling save().
@@ -595,6 +613,7 @@ export class Store {
 		this.save();
 
 		const pageRef = this.getPageRefById(id);
+
 		if (pageRef && pageRef.getLastPersistedPath()) {
 			const pagePath: string = Path.join(
 				this.getPagesPath(),


### PR DESCRIPTION
Extend the page list view with a floating button that adds a new page to the list

* Appends page always at end of list
* Selects and focuses new page for editing 

---

Usefulness very limited via https://github.com/meetalva/alva/issues/387, let's tackle this next

Fixes #24 

<details>
<summary>Screencast</summary>

![add-page](https://user-images.githubusercontent.com/4248851/39654803-c35fba88-4ff6-11e8-80fb-34fe035383a7.gif)

</details>