### PR TITLE
refactor: model element roles explicity

### DIFF
--- a/src/container/element-list/element-container.tsx
+++ b/src/container/element-list/element-container.tsx
@@ -15,12 +15,11 @@ export class ElementContainer extends React.Component<ElementContainerProps> {
 	public render(): JSX.Element | null {
 		const store = ViewStore.getInstance();
 		const { props } = this;
-		const open =
-			props.element.getOpen() || props.element.getForcedOpen();
+		const open = props.element.getOpen() || props.element.getForcedOpen();
 
 		// Ensure mobx registers
 		props.element.getSelected();
-		props.element.isNameEditable();
+		props.element.getNameEditable();
 		props.element.getHighlighted();
 		props.element.acceptsChildren();
 
@@ -51,7 +50,7 @@ export class ElementContainer extends React.Component<ElementContainerProps> {
 const getState = (element: Model.Element): Components.ElementState => {
 	const store = ViewStore.getInstance();
 
-	if (element.getSelected() && element.isNameEditable()) {
+	if (element.getSelected() && element.getNameEditable()) {
 		return Components.ElementState.Editable;
 	}
 

--- a/src/container/element-list/element-list.tsx
+++ b/src/container/element-list/element-list.tsx
@@ -171,7 +171,7 @@ export class ElementList extends React.Component {
 			return;
 		}
 
-		if (draggedElement.isNameEditable()) {
+		if (draggedElement.getNameEditable()) {
 			e.preventDefault();
 			return;
 		}
@@ -302,7 +302,10 @@ export class ElementList extends React.Component {
 		const element = elementFromTarget(e.target as HTMLElement, { sibling: false });
 		const label = above(e.target, `[${ElementAnchors.label}]`);
 
-		if ((label && element) || (!label && element && element.isRoot())) {
+		if (
+			(label && element) ||
+			(!label && element && element.getRole() === Types.ElementRole.Root)
+		) {
 			store
 				.getProject()
 				.getElements()

--- a/src/container/pattern-list/pattern-item-container.tsx
+++ b/src/container/pattern-list/pattern-item-container.tsx
@@ -11,10 +11,24 @@ export class PatternItemContainer extends React.Component<PatternItemContainerCo
 	private handleDoubleClick(e: React.MouseEvent<HTMLElement>): void {
 		const store = ViewStore.getInstance();
 		const element = store.createElement({ pattern: this.props.pattern });
-		const selectedElement = store.getSelectedElement();
-		const page = store.getCurrentPage();
 
-		const targetElement = selectedElement ? selectedElement : page ? page.getRoot() : null;
+		const getTargetElement = () => {
+			const selectedElement = store.getSelectedElement();
+
+			if (selectedElement) {
+				return selectedElement;
+			}
+
+			const page = store.getCurrentPage();
+
+			if (page) {
+				return page.getRoot();
+			}
+
+			return undefined;
+		};
+
+		const targetElement = getTargetElement();
 
 		if (element && targetElement) {
 			store.addElement(element);

--- a/src/electron/context-menus.ts
+++ b/src/electron/context-menus.ts
@@ -3,6 +3,7 @@ import { MenuItemConstructorOptions, remote } from 'electron';
 import { ServerMessageType } from '../message';
 import { Element } from '../model';
 import { ViewStore } from '../store';
+import * as Types from '../model/types';
 import * as uuid from 'uuid';
 
 const store = ViewStore.getInstance();
@@ -11,7 +12,8 @@ export function elementMenu(element: Element): void {
 	const defaultPasteItems = [
 		{
 			label: 'Paste Below',
-			enabled: store.hasApplicableClipboardItem() && !element.isRoot(),
+			enabled:
+				store.hasApplicableClipboardItem() && element.getRole() !== Types.ElementRole.Root,
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),
@@ -33,7 +35,7 @@ export function elementMenu(element: Element): void {
 		},
 		{
 			label: 'Duplicate',
-			enabled: !element.isRoot(),
+			enabled: element.getRole() !== Types.ElementRole.Root,
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),
@@ -47,7 +49,7 @@ export function elementMenu(element: Element): void {
 	const template: MenuItemConstructorOptions[] = [
 		{
 			label: 'Cut',
-			enabled: !element.isRoot(),
+			enabled: element.getRole() !== Types.ElementRole.Root,
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),
@@ -59,7 +61,7 @@ export function elementMenu(element: Element): void {
 		},
 		{
 			label: 'Copy',
-			enabled: !element.isRoot(),
+			enabled: element.getRole() !== Types.ElementRole.Root,
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),
@@ -71,7 +73,7 @@ export function elementMenu(element: Element): void {
 		},
 		{
 			label: 'Delete',
-			enabled: !element.isRoot(),
+			enabled: element.getRole() !== Types.ElementRole.Root,
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),
@@ -92,7 +94,7 @@ export function elementMenu(element: Element): void {
 				remote.Menu.sendActionToFirstResponder('paste:');
 			}
 		} */
-		...(!element.isNameEditable() ? defaultPasteItems : [])
+		...(!element.getNameEditable() ? defaultPasteItems : [])
 	];
 
 	remote.Menu.buildFromTemplate(template).popup({});

--- a/src/model/page/page.ts
+++ b/src/model/page/page.ts
@@ -96,6 +96,7 @@ export class Page {
 				patternId: rootPattern.getId(),
 				placeholderHighlighted: false,
 				properties: [],
+				role: Types.ElementRole.Root,
 				setDefaults: true,
 				selected: false
 			},

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -24,6 +24,8 @@ export interface SerializedPage {
 	rootId: string;
 }
 
+export type SerializedElementRole = 'root' | 'node';
+
 export interface SerializedElement {
 	containerId?: string;
 	contentIds: string[];
@@ -36,6 +38,7 @@ export interface SerializedElement {
 	patternId: string;
 	placeholderHighlighted: boolean;
 	properties: SerializedElementProperty[];
+	role: SerializedElementRole;
 	selected: boolean;
 }
 
@@ -371,4 +374,9 @@ export interface RenderInit {
 
 export interface SelectPayload {
 	id: string;
+}
+
+export enum ElementRole {
+	Root = 'root',
+	Node = 'node'
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -572,6 +572,10 @@ export class ViewStore {
 		element: Model.Element;
 		targetElement: Model.Element;
 	}): Model.Element | undefined {
+		if (init.element.isRoot()) {
+			return;
+		}
+
 		if (init.targetElement.isRoot()) {
 			return this.insertInsideElement(init);
 		}
@@ -599,6 +603,10 @@ export class ViewStore {
 		element: Model.Element;
 		targetElement: Model.Element;
 	}): Model.Element | undefined {
+		if (init.element.isRoot()) {
+			return;
+		}
+
 		const contents = init.targetElement.getContentBySlotType(Types.SlotType.Children);
 
 		if (!contents) {

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -246,7 +246,7 @@ export class ViewStore {
 	 */
 	@Mobx.action
 	public cutElement(element: Model.Element): void {
-		if (element.isRoot()) {
+		if (element.getRole() === Types.ElementRole.Root) {
 			return;
 		}
 
@@ -572,11 +572,11 @@ export class ViewStore {
 		element: Model.Element;
 		targetElement: Model.Element;
 	}): Model.Element | undefined {
-		if (init.element.isRoot()) {
+		if (init.element.getRole() === Types.ElementRole.Root) {
 			return;
 		}
 
-		if (init.targetElement.isRoot()) {
+		if (init.targetElement.getRole() === Types.ElementRole.Root) {
 			return this.insertInsideElement(init);
 		}
 
@@ -603,7 +603,7 @@ export class ViewStore {
 		element: Model.Element;
 		targetElement: Model.Element;
 	}): Model.Element | undefined {
-		if (init.element.isRoot()) {
+		if (init.element.getRole() === Types.ElementRole.Root) {
 			return;
 		}
 
@@ -736,7 +736,7 @@ export class ViewStore {
 
 	@Mobx.action
 	public removeElement(element: Model.Element): void {
-		if (element.isRoot()) {
+		if (element.getRole() === Types.ElementRole.Root) {
 			return;
 		}
 
@@ -864,7 +864,7 @@ export class ViewStore {
 	@Mobx.action
 	public setClipboardItem(item: Model.Element | Model.Page): void {
 		if (item instanceof Model.Element) {
-			if (item.isRoot()) {
+			if (item.getRole() === Types.ElementRole.Root) {
 				return;
 			}
 


### PR DESCRIPTION
Instead of finding out if an element is the page root or not by checking if it has an container, introduce the explicit `role` field on Element. Defaults to `ElementRole.Node` if not set. Specify `ElementRole.Root` for root elements.