### PR TITLE
refactor: replace store singleton with dependency injection

### DIFF
--- a/src/command/element-command.ts
+++ b/src/command/element-command.ts
@@ -23,6 +23,8 @@ export abstract class ElementCommand extends Command {
 	 */
 	protected pageId: string;
 
+	protected store: ViewStore;
+
 	/**
 	 * Creates a new user operation on a page element.
 	 * @param element The element the user operation is performed on.
@@ -33,9 +35,10 @@ export abstract class ElementCommand extends Command {
 	 * the operation edits 'image.src.srcSet.xs' on the element.
 	 */
 	// tslint:disable-next-line:no-any
-	public constructor(element: Element) {
+	public constructor(element: Element, store: ViewStore) {
 		super();
 
+		this.store = store;
 		this.element = element;
 
 		// Memorize the element and page IDs.
@@ -55,16 +58,15 @@ export abstract class ElementCommand extends Command {
 	 * @return Whether the operation was successful. On failure, the execute/undo should abort.
 	 */
 	protected ensurePageAndElement(): boolean {
-		const store = ViewStore.getInstance();
-		const currentPage = store.getCurrentPage();
+		const currentPage = this.store.getCurrentPage();
 
 		if (!currentPage || currentPage.getId() !== this.pageId) {
-			store.setActivePageById(this.pageId);
+			this.store.setActivePageById(this.pageId);
 			return true;
 		}
 
 		if (this.elementId) {
-			const element = store.getElementById(this.elementId);
+			const element = this.store.getElementById(this.elementId);
 			if (!element) {
 				return false;
 			}
@@ -85,7 +87,7 @@ export abstract class ElementCommand extends Command {
 		const page = this.element.getPage();
 
 		if (page) {
-			ViewStore.getInstance().setSelectedElement(this.element);
+			this.store.setSelectedElement(this.element);
 		}
 
 		return true;
@@ -116,7 +118,7 @@ export abstract class ElementCommand extends Command {
 		}
 
 		if (this.element.getPage()) {
-			ViewStore.getInstance().setSelectedElement(this.element);
+			this.store.setSelectedElement(this.element);
 		}
 
 		return true;

--- a/src/command/element-location-command.ts
+++ b/src/command/element-location-command.ts
@@ -17,10 +17,16 @@ export class ElementLocationCommand extends ElementCommand {
 	protected previousContentId: string;
 	protected previousIndex: number;
 
-	public constructor(init: { contentId: string; elementId: string; index: number }) {
-		super((ViewStore.getInstance().getProject() as Project).getElementById(
-			init.elementId
-		) as Element);
+	public constructor(init: {
+		contentId: string;
+		elementId: string;
+		index: number;
+		store: ViewStore;
+	}) {
+		super(
+			(init.store.getProject() as Project).getElementById(init.elementId) as Element,
+			init.store
+		);
 		this.index = init.index;
 		this.contentId = init.contentId;
 	}
@@ -39,19 +45,27 @@ export class ElementLocationCommand extends ElementCommand {
 		childId: string;
 		contentId: string;
 		index: number;
+		store: ViewStore;
 	}): ElementCommand {
 		return new ElementLocationCommand({
 			elementId: init.childId,
 			contentId: init.contentId,
-			index: init.index
+			index: init.index,
+			store: init.store
 		});
 	}
 
-	public static setParent(childId: string, contentId: string, index: number): ElementCommand {
+	public static setParent(
+		childId: string,
+		contentId: string,
+		index: number,
+		store: ViewStore
+	): ElementCommand {
 		return new ElementLocationCommand({
 			elementId: childId,
 			contentId,
-			index
+			index,
+			store
 		});
 	}
 
@@ -63,8 +77,7 @@ export class ElementLocationCommand extends ElementCommand {
 			return false;
 		}
 
-		const store = ViewStore.getInstance();
-		const project = store.getProject();
+		const project = this.store.getProject();
 
 		if (!project || !this.contentId) {
 			return false;
@@ -112,8 +125,7 @@ export class ElementLocationCommand extends ElementCommand {
 			return false;
 		}
 
-		const store = ViewStore.getInstance();
-		const project = store.getProject();
+		const project = this.store.getProject();
 
 		if (!project) {
 			return false;

--- a/src/command/element-name-command.ts
+++ b/src/command/element-name-command.ts
@@ -1,6 +1,7 @@
 import { Command } from './command';
 import { ElementCommand } from './element-command';
 import { Element } from '../model';
+import { ViewStore } from '../store';
 
 /**
  * A user operation to set the name of a page element.
@@ -22,8 +23,8 @@ export class ElementNameCommand extends ElementCommand {
 	 * @param name The new name for the page element.
 	 */
 	// tslint:disable-next-line:no-any
-	public constructor(element: Element, name: string) {
-		super(element);
+	public constructor(element: Element, name: string, store: ViewStore) {
+		super(element, store);
 
 		this.name = name.length === 0 ? element.getName({ unedited: true }) : name;
 		this.previousName = element.getName({ unedited: true });

--- a/src/command/element-remove-command.ts
+++ b/src/command/element-remove-command.ts
@@ -8,8 +8,8 @@ export class ElementRemoveCommand extends ElementCommand {
 	protected index: number;
 	protected page: Page;
 
-	public constructor(init: { element: Element }) {
-		super(init.element);
+	public constructor(init: { element: Element; store: ViewStore }) {
+		super(init.element, init.store);
 
 		this.container = this.element.getContainer() as ElementContent;
 		this.index = this.element.getIndex();
@@ -58,14 +58,12 @@ export class ElementRemoveCommand extends ElementCommand {
 			return false;
 		}
 
-		const store = ViewStore.getInstance();
-
 		this.container.insert({
 			element: this.element,
 			at: this.index
 		});
 
-		store.setSelectedElement(this.element);
+		this.store.setSelectedElement(this.element);
 
 		return true;
 	}

--- a/src/command/page-add-command.ts
+++ b/src/command/page-add-command.ts
@@ -6,22 +6,22 @@ import * as Types from '../model/types';
 export class PageAddCommand extends Command {
 	private page: Page;
 	private project: Project;
+	private store: ViewStore;
 
-	private constructor(init: { page: Page; project: Project }) {
+	private constructor(init: { page: Page; project: Project; store: ViewStore }) {
 		super();
 		this.page = init.page;
 		this.project = init.project;
+		this.store = init.store;
 	}
 
-	public static create(init: { page: Page; project: Project }): PageAddCommand {
+	public static create(init: { page: Page; project: Project; store: ViewStore }): PageAddCommand {
 		return new PageAddCommand(init);
 	}
 
 	public execute(): boolean {
-		const store = ViewStore.getInstance();
-
 		this.project.addPage(this.page);
-		store.setActivePage(this.page);
+		this.store.setActivePage(this.page);
 		return true;
 	}
 
@@ -30,14 +30,13 @@ export class PageAddCommand extends Command {
 	}
 
 	public undo(): boolean {
-		const store = ViewStore.getInstance();
 		const index = this.project.getPageIndex(this.page);
 
 		if (index === 0) {
-			store.unsetActivePage();
-			store.setActiveView(Types.AlvaView.Pages);
+			this.store.unsetActivePage();
+			this.store.setActiveView(Types.AlvaView.Pages);
 		} else {
-			store.setActivePageByIndex(index - 1);
+			this.store.setActivePageByIndex(index - 1);
 		}
 
 		return this.project.removePage(this.page);

--- a/src/command/page-remove-command.ts
+++ b/src/command/page-remove-command.ts
@@ -6,26 +6,30 @@ import * as Types from '../model/types';
 export class PageRemoveCommand extends Command {
 	private page: Page;
 	private project: Project;
+	private store: ViewStore;
 
-	private constructor(init: { page: Page; project: Project }) {
+	private constructor(init: { page: Page; project: Project; store: ViewStore }) {
 		super();
 		this.page = init.page;
 		this.project = init.project;
 	}
 
-	public static create(init: { page: Page; project: Project }): PageRemoveCommand {
+	public static create(init: {
+		page: Page;
+		project: Project;
+		store: ViewStore;
+	}): PageRemoveCommand {
 		return new PageRemoveCommand(init);
 	}
 
 	public execute(): boolean {
-		const store = ViewStore.getInstance();
 		const index = this.project.getPageIndex(this.page);
 
 		if (index === 0) {
-			store.unsetActivePage();
-			store.setActiveView(Types.AlvaView.Pages);
+			this.store.unsetActivePage();
+			this.store.setActiveView(Types.AlvaView.Pages);
 		} else {
-			store.setActivePageByIndex(index - 1);
+			this.store.setActivePageByIndex(index - 1);
 		}
 
 		this.project.removePage(this.page);
@@ -37,10 +41,8 @@ export class PageRemoveCommand extends Command {
 	}
 
 	public undo(): boolean {
-		const store = ViewStore.getInstance();
-
 		this.project.addPage(this.page);
-		store.setActivePage(this.page);
+		this.store.setActivePage(this.page);
 		return true;
 	}
 }

--- a/src/command/property-value-command.ts
+++ b/src/command/property-value-command.ts
@@ -1,6 +1,7 @@
 import { Command } from './command';
 import { ElementCommand } from './element-command';
 import { Element } from '../model';
+import { ViewStore } from '../store';
 
 /**
  * A user operation to set the value of a page element property.
@@ -45,12 +46,11 @@ export class PropertyValueCommand extends ElementCommand {
 	 * the operation edits 'image.src.srcSet.xs' on the element.
 	 */
 	// tslint:disable-next-line:no-any
-	public constructor(element: Element, propertyId: string, value: any, path?: string) {
-		super(element);
+	public constructor(element: Element, propertyId: string, value: any, store: ViewStore) {
+		super(element, store);
 
 		this.propertyId = propertyId;
 		this.value = value;
-		this.path = path;
 		// 		this.previousValue = element.getPropertyValue(propertyId, path);
 	}
 

--- a/src/container/app.tsx
+++ b/src/container/app.tsx
@@ -33,48 +33,17 @@ const Resizeable = require('re-resizable');
 
 globalStyles();
 
+interface InjectedAppProps {
+	store: ViewStore;
+}
+
+@MobxReact.inject('store')
 @MobxReact.observer
 export class App extends React.Component {
-	private ctrlDown: boolean = false;
-	private shiftDown: boolean = false;
-
-	public componentDidMount(): void {
-		this.redirectUndoRedo();
-	}
-
-	private redirectUndoRedo(): void {
-		document.body.onkeydown = event => {
-			if (event.keyCode === 16) {
-				this.shiftDown = true;
-			} else if (event.keyCode === 17 || event.keyCode === 91) {
-				this.ctrlDown = true;
-			} else if (this.ctrlDown && event.keyCode === 90) {
-				event.preventDefault();
-				if (this.shiftDown) {
-					ViewStore.getInstance().redo();
-				} else {
-					ViewStore.getInstance().undo();
-				}
-
-				return false;
-			}
-
-			return true;
-		};
-
-		document.body.onkeyup = event => {
-			if (event.keyCode === 16) {
-				this.shiftDown = false;
-			} else if (event.keyCode === 17 || event.keyCode === 91) {
-				this.ctrlDown = false;
-			}
-		};
-	}
-
 	public render(): JSX.Element | null {
-		const store = ViewStore.getInstance();
+		const props = this.props as InjectedAppProps;
 
-		if (store.getAppState() !== Types.AppState.Started) {
+		if (props.store.getAppState() !== Types.AppState.Started) {
 			return null;
 		}
 
@@ -82,7 +51,7 @@ export class App extends React.Component {
 			<Layout direction={LayoutDirection.Column}>
 				<ChromeContainer />
 				<MainArea>
-					{store.getActiveView() === Types.AlvaView.SplashScreen && (
+					{props.store.getActiveView() === Types.AlvaView.SplashScreen && (
 						<SplashScreenContainer
 							onPrimaryButtonClick={() => {
 								Sender.send({
@@ -100,12 +69,12 @@ export class App extends React.Component {
 							}}
 						/>
 					)}
-					{store.getActiveView() === Types.AlvaView.Pages && (
+					{props.store.getActiveView() === Types.AlvaView.Pages && (
 						<PageListPreview>
 							<PageListContainer />
 						</PageListPreview>
 					)}
-					{store.getActiveView() === Types.AlvaView.PageDetail && (
+					{props.store.getActiveView() === Types.AlvaView.PageDetail && (
 						<React.Fragment>
 							<Resizeable
 								handleStyles={{ right: { zIndex: 1 } }}
@@ -116,7 +85,7 @@ export class App extends React.Component {
 								<SideBar
 									side={LayoutSide.Left}
 									direction={LayoutDirection.Column}
-									onClick={() => store.unsetSelectedElement()}
+									onClick={() => props.store.unsetSelectedElement()}
 									border={LayoutBorder.Side}
 								>
 									<ElementPane>
@@ -137,7 +106,7 @@ export class App extends React.Component {
 							</Resizeable>
 							<PreviewPaneWrapper
 								key="center"
-								previewFrame={`http://localhost:${store.getServerPort()}/preview.html`}
+								previewFrame={`http://localhost:${props.store.getServerPort()}/preview.html`}
 							/>
 							<Resizeable
 								handleStyles={{ left: { zIndex: 1 } }}
@@ -150,10 +119,10 @@ export class App extends React.Component {
 									direction={LayoutDirection.Column}
 									border={LayoutBorder.Side}
 								>
-									{store.getPatternLibraryState() ===
+									{props.store.getPatternLibraryState() ===
 										Types.PatternLibraryState.Pristine && (
 										<ConnectPaneContainer
-											onPrimaryButtonClick={() => store.connectPatternLibrary()}
+											onPrimaryButtonClick={() => props.store.connectPatternLibrary()}
 										/>
 									)}
 									<PropertyPane>

--- a/src/container/chrome/chrome-container.tsx
+++ b/src/container/chrome/chrome-container.tsx
@@ -6,56 +6,63 @@ import * as React from 'react';
 import { ViewStore } from '../../store';
 import * as Types from '../../model/types';
 
-export const ChromeContainer = MobxReact.observer((props): JSX.Element | null => {
-	const store = ViewStore.getInstance();
-	const project = store.getProject();
+interface InjectedChromeContainerProps {
+	store: ViewStore;
+}
 
-	if (!project) {
-		return null;
-	}
+export const ChromeContainer = MobxReact.inject('store')(
+	MobxReact.observer((props): JSX.Element | null => {
+		const { store } = props as InjectedChromeContainerProps;
+		const project = store.getProject();
 
-	const page = store.getCurrentPage();
+		if (!project) {
+			return null;
+		}
 
-	if (!page) {
-		return null;
-	}
+		const page = store.getCurrentPage();
 
-	const index = project.getPageIndex(page);
-	const pages = project.getPages();
+		if (!page) {
+			return null;
+		}
 
-	if (typeof index !== 'number') {
-		return null;
-	}
+		const index = project.getPageIndex(page);
+		const pages = project.getPages();
 
-	const previous = index > 0 ? () => store.setActivePageByIndex(index - 1) : AlvaUtil.noop;
-	const next = index < pages.length ? () => store.setActivePageByIndex(index + 1) : AlvaUtil.noop;
+		if (typeof index !== 'number') {
+			return null;
+		}
 
-	return (
-		<Chrome>
-			{store.getActiveView() === Types.AlvaView.PageDetail ? (
-				<OverviewSwitchContainer />
-			) : (
-				<div />
-			)}
-			{store.getActiveView() === Types.AlvaView.PageDetail && (
-				<ViewSwitch
-					fontSize={CopySize.M}
-					justify="center"
-					leftVisible={index > 0}
-					rightVisible={index < pages.length - 1}
-					onLeftClick={previous}
-					onRightClick={next}
-					title={page ? page.getName() : ''}
-				/>
-			)}
-			{store.getActiveView() === Types.AlvaView.Pages && (
-				<ViewTitle
-					fontSize={CopySize.M}
-					justify="center"
-					title={project ? project.getName() : 'Alva'}
-				/>
-			)}
-			{props.children}
-		</Chrome>
-	);
-});
+		const previous = index > 0 ? () => store.setActivePageByIndex(index - 1) : AlvaUtil.noop;
+		const next =
+			index < pages.length ? () => store.setActivePageByIndex(index + 1) : AlvaUtil.noop;
+
+		return (
+			<Chrome>
+				{store.getActiveView() === Types.AlvaView.PageDetail ? (
+					<OverviewSwitchContainer />
+				) : (
+					<div />
+				)}
+				{store.getActiveView() === Types.AlvaView.PageDetail && (
+					<ViewSwitch
+						fontSize={CopySize.M}
+						justify="center"
+						leftVisible={index > 0}
+						rightVisible={index < pages.length - 1}
+						onLeftClick={previous}
+						onRightClick={next}
+						title={page ? page.getName() : ''}
+					/>
+				)}
+				{store.getActiveView() === Types.AlvaView.Pages && (
+					<ViewTitle
+						fontSize={CopySize.M}
+						justify="center"
+						title={project ? project.getName() : 'Alva'}
+					/>
+				)}
+				{props.children}
+			</Chrome>
+		);
+	})
+);

--- a/src/container/chrome/overview-switch-container.tsx
+++ b/src/container/chrome/overview-switch-container.tsx
@@ -4,10 +4,11 @@ import * as React from 'react';
 import { ViewStore } from '../../store';
 import * as Types from '../../model/types';
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class OverviewSwitchContainer extends React.Component {
 	public render(): JSX.Element | null {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as { store: ViewStore };
 		const project = store.getProject();
 		const page = store.getCurrentPage();
 

--- a/src/container/element-list/element-container.tsx
+++ b/src/container/element-list/element-container.tsx
@@ -10,10 +10,12 @@ export interface ElementContainerProps {
 	element: Model.Element;
 }
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class ElementContainer extends React.Component<ElementContainerProps> {
 	public render(): JSX.Element | null {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as ElementContainerProps & { store: ViewStore };
+
 		const { props } = this;
 		const open = props.element.getOpen() || props.element.getForcedOpen();
 
@@ -32,7 +34,7 @@ export class ElementContainer extends React.Component<ElementContainerProps> {
 				open={open}
 				onChange={AlvaUtil.noop}
 				placeholderHighlighted={props.element.getPlaceholderHighlighted()}
-				state={getState(props.element)}
+				state={getState(props.element, store)}
 				title={props.element.getName()}
 			>
 				{open
@@ -47,9 +49,7 @@ export class ElementContainer extends React.Component<ElementContainerProps> {
 	}
 }
 
-const getState = (element: Model.Element): Components.ElementState => {
-	const store = ViewStore.getInstance();
-
+const getState = (element: Model.Element, store: ViewStore): Components.ElementState => {
 	if (element.getSelected() && element.getNameEditable()) {
 		return Components.ElementState.Editable;
 	}

--- a/src/container/element-list/element-list.tsx
+++ b/src/container/element-list/element-list.tsx
@@ -20,6 +20,7 @@ const DRAG_IMG_STYLE = `
 	opacity: 1;
 `;
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class ElementList extends React.Component {
 	private dragImg?: HTMLElement;
@@ -29,7 +30,7 @@ export class ElementList extends React.Component {
 	private ref: HTMLElement | null;
 
 	public componentDidMount(): void {
-		const store = Store.ViewStore.getInstance();
+		const { store } = this.props as { store: Store.ViewStore };
 		this.globalKeyDownListener = e => this.handleKeyDown(e);
 		this.globalDragEndListener = e => store.unsetDraggedElement();
 		this.globalDropListener = this.globalDragEndListener;
@@ -52,7 +53,7 @@ export class ElementList extends React.Component {
 	}
 
 	private handleBlur(e: React.FormEvent<HTMLElement>): void {
-		const store = Store.ViewStore.getInstance();
+		const { store } = this.props as { store: Store.ViewStore };
 		const editableElement = store.getNameEditableElement();
 
 		if (editableElement) {
@@ -62,8 +63,9 @@ export class ElementList extends React.Component {
 	}
 
 	private handleChange(e: React.FormEvent<HTMLElement>): void {
+		const { store } = this.props as { store: Store.ViewStore };
 		const target = e.target as HTMLInputElement;
-		const changedElement = elementFromTarget(e.target, { sibling: false });
+		const changedElement = elementFromTarget(e.target, { sibling: false, store });
 
 		if (changedElement) {
 			changedElement.setName(target.value);
@@ -71,6 +73,8 @@ export class ElementList extends React.Component {
 	}
 
 	private handleClick(e: React.MouseEvent<HTMLElement>): void {
+		const { store } = this.props as { store: Store.ViewStore };
+
 		const target = e.target as HTMLElement;
 		const icon = above(target, `svg[${ElementAnchors.icon}]`);
 
@@ -79,8 +83,7 @@ export class ElementList extends React.Component {
 			return;
 		}
 
-		const element = elementFromTarget(e.target, { sibling: false });
-		const store = Store.ViewStore.getInstance();
+		const element = elementFromTarget(e.target, { sibling: false, store });
 		const label = above(e.target, `[${ElementAnchors.label}]`);
 
 		if (!element) {
@@ -104,9 +107,10 @@ export class ElementList extends React.Component {
 	}
 
 	private handleContextMenu(e: React.MouseEvent<HTMLElement>): void {
-		const element = elementFromTarget(e.target, { sibling: false });
+		const { store } = this.props as { store: Store.ViewStore };
+		const element = elementFromTarget(e.target, { sibling: false, store });
 		if (element) {
-			elementMenu(element);
+			elementMenu(element, store);
 		}
 	}
 
@@ -117,7 +121,8 @@ export class ElementList extends React.Component {
 	}
 
 	private handleDragLeave(e: React.DragEvent<HTMLElement>): void {
-		const targetElement = elementFromTarget(e.target, { sibling: false });
+		const { store } = this.props as { store: Store.ViewStore };
+		const targetElement = elementFromTarget(e.target, { sibling: false, store });
 
 		if (!targetElement) {
 			return;
@@ -128,13 +133,13 @@ export class ElementList extends React.Component {
 	}
 
 	private handleDragOver(e: React.DragEvent<HTMLElement>): void {
+		const { store } = this.props as { store: Store.ViewStore };
 		const target = e.target as HTMLElement;
 		const isSibling = target.getAttribute(ElementAnchors.placeholder) === 'true';
 
-		const targetParentElement = elementFromTarget(target, { sibling: isSibling });
-		const visualTargetElement = elementFromTarget(target, { sibling: false });
+		const targetParentElement = elementFromTarget(target, { sibling: isSibling, store });
+		const visualTargetElement = elementFromTarget(target, { sibling: false, store });
 
-		const store = Store.ViewStore.getInstance();
 		const draggedElement = store.getDraggedElement();
 
 		if (!targetParentElement || !visualTargetElement) {
@@ -163,8 +168,8 @@ export class ElementList extends React.Component {
 	}
 
 	private handleDragStart(e: React.DragEvent<HTMLElement>): void {
-		const store = Store.ViewStore.getInstance();
-		const draggedElement = elementFromTarget(e.target, { sibling: false });
+		const { store } = this.props as { store: Store.ViewStore };
+		const draggedElement = elementFromTarget(e.target, { sibling: false, store });
 
 		if (!draggedElement) {
 			e.preventDefault();
@@ -193,15 +198,16 @@ export class ElementList extends React.Component {
 	}
 
 	private handleDrop(e: React.DragEvent<HTMLElement>): void {
+		const { store } = this.props as { store: Store.ViewStore };
+
 		this.handleDragEnd(e);
 
-		const store = Store.ViewStore.getInstance();
 		const target = e.target as HTMLElement;
 		const isSiblingDrop = target.getAttribute(ElementAnchors.placeholder) === 'true';
 
-		const rawTargetElement = elementFromTarget(e.target, { sibling: false });
-		const dropTargetElement = elementFromTarget(e.target, { sibling: isSiblingDrop });
-		const dropTargetContent = contentFromTarget(e.target, { sibling: isSiblingDrop });
+		const rawTargetElement = elementFromTarget(e.target, { sibling: false, store });
+		const dropTargetElement = elementFromTarget(e.target, { sibling: isSiblingDrop, store });
+		const dropTargetContent = contentFromTarget(e.target, { sibling: isSiblingDrop, store });
 		const draggedElement = store.getDraggedElement();
 
 		if (!rawTargetElement || !dropTargetElement || !dropTargetContent || !draggedElement) {
@@ -247,7 +253,7 @@ export class ElementList extends React.Component {
 	}
 
 	private handleKeyDown(e: KeyboardEvent): void {
-		const store = Store.ViewStore.getInstance();
+		const { store } = this.props as { store: Store.ViewStore };
 		const node = e.target as Node;
 		const contains = (target: Node) => (this.ref ? this.ref.contains(target) : false);
 
@@ -290,7 +296,8 @@ export class ElementList extends React.Component {
 	}
 
 	private handleMouseLeave(e: React.MouseEvent<HTMLElement>): void {
-		const element = elementFromTarget(e.target as HTMLElement, { sibling: false });
+		const { store } = this.props as { store: Store.ViewStore };
+		const element = elementFromTarget(e.target as HTMLElement, { sibling: false, store });
 
 		if (element) {
 			element.setHighlighted(false);
@@ -298,8 +305,8 @@ export class ElementList extends React.Component {
 	}
 
 	private handleMouseOver(e: React.MouseEvent<HTMLElement>): void {
-		const store = Store.ViewStore.getInstance();
-		const element = elementFromTarget(e.target as HTMLElement, { sibling: false });
+		const { store } = this.props as { store: Store.ViewStore };
+		const element = elementFromTarget(e.target as HTMLElement, { sibling: false, store });
 		const label = above(e.target, `[${ElementAnchors.label}]`);
 
 		if (
@@ -319,7 +326,7 @@ export class ElementList extends React.Component {
 	}
 
 	public render(): JSX.Element | null {
-		const store = Store.ViewStore.getInstance();
+		const { store } = this.props as { store: Store.ViewStore };
 		const page: Model.Page | undefined = store.getCurrentPage();
 
 		if (!page) {
@@ -383,7 +390,7 @@ function above(node: EventTarget, selector: string): HTMLElement | null {
 
 function contentFromTarget(
 	target: EventTarget,
-	options: { sibling: boolean }
+	options: { sibling: boolean; store: Store.ViewStore }
 ): Model.ElementContent | undefined {
 	const el = above(target, `[${ElementAnchors.content}]`);
 
@@ -397,9 +404,8 @@ function contentFromTarget(
 		return;
 	}
 
-	const store = Store.ViewStore.getInstance();
-	const content = store.getContentById(id);
-	const element = store.getElementById(id);
+	const content = options.store.getContentById(id);
+	const element = options.store.getElementById(id);
 
 	if (content) {
 		return content;
@@ -420,7 +426,7 @@ function contentFromTarget(
 
 function elementFromTarget(
 	target: EventTarget,
-	options: { sibling: boolean }
+	options: { sibling: boolean; store: Store.ViewStore }
 ): Model.Element | undefined {
 	const el = above(target, `[${ElementAnchors.element}]`);
 
@@ -434,8 +440,7 @@ function elementFromTarget(
 		return;
 	}
 
-	const store = Store.ViewStore.getInstance();
-	const element = store.getElementById(id);
+	const element = options.store.getElementById(id);
 
 	if (!element) {
 		return;

--- a/src/container/page-list/page-list-container.tsx
+++ b/src/container/page-list/page-list-container.tsx
@@ -5,9 +5,9 @@ import { PageTileContainer } from './page-tile-container';
 import * as React from 'react';
 import { ViewStore } from '../../store';
 
-export const PageListContainer: React.StatelessComponent = MobxReact.observer(
-	(): JSX.Element | null => {
-		const store = ViewStore.getInstance();
+export const PageListContainer: React.StatelessComponent = MobxReact.inject('store')(
+	MobxReact.observer((props): JSX.Element | null => {
+		const { store } = props as { store: ViewStore };
 		const project = store.getProject();
 		const currentPage = store.getCurrentPage();
 		const currentPageId = currentPage ? currentPage.getId() : undefined;
@@ -32,5 +32,5 @@ export const PageListContainer: React.StatelessComponent = MobxReact.observer(
 				</Layout>
 			</Space>
 		);
-	}
+	})
 );

--- a/src/container/page-list/page-list-preview.tsx
+++ b/src/container/page-list/page-list-preview.tsx
@@ -1,30 +1,30 @@
-import { colors, Copy, Headline, Space, SpaceSize } from '../../components';
+import { colors, Headline, Space, SpaceSize } from '../../components';
+import * as MobxReact from 'mobx-react';
 import * as React from 'react';
 import { ViewStore } from '../../store';
 import styled from 'styled-components';
 
-export const PageListPreview: React.StatelessComponent = props => {
-	const project = ViewStore.getInstance().getProject();
-	if (!project) {
-		return <>props.children</>;
-	}
-	const dateString = new Intl.DateTimeFormat().format(project.getLastChangedDate());
-	return (
-		<StyledPageListPreview>
-			<Space size={[SpaceSize.XXL * 3]}>
-				<Space size={[SpaceSize.S, SpaceSize.S, SpaceSize.XXXL]}>
-					<Headline order={1} tagName="h1" textColor={colors.grey20}>
-						{project.getName()}
-					</Headline>
-					<Copy textColor={colors.grey60}>
-						Last change: {dateString} by {project.getLastChangedAuthor()}
-					</Copy>
+export const PageListPreview: React.StatelessComponent = MobxReact.inject('store')(
+	MobxReact.observer(props => {
+		const { store } = props as { store: ViewStore };
+		const project = store.getProject();
+		if (!project) {
+			return <>props.children</>;
+		}
+		return (
+			<StyledPageListPreview>
+				<Space size={[SpaceSize.XXL * 3]}>
+					<Space size={[SpaceSize.S, SpaceSize.S, SpaceSize.XXXL]}>
+						<Headline order={1} tagName="h1" textColor={colors.grey20}>
+							{project.getName()}
+						</Headline>
+					</Space>
+					{props.children}
 				</Space>
-				{props.children}
-			</Space>
-		</StyledPageListPreview>
-	);
-};
+			</StyledPageListPreview>
+		);
+	})
+);
 
 const StyledPageListPreview = styled.div`
 	box-sizing: border-box;

--- a/src/container/page-list/page-tile-container.tsx
+++ b/src/container/page-list/page-tile-container.tsx
@@ -10,6 +10,7 @@ export interface PageTileContainerProps {
 	page: Page;
 }
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class PageTileContainer extends React.Component<PageTileContainerProps> {
 	private onKeyDown: (e: KeyboardEvent) => void;
@@ -41,7 +42,7 @@ export class PageTileContainer extends React.Component<PageTileContainerProps> {
 	}
 
 	protected handleClick(e: React.MouseEvent<HTMLElement>): void {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as PageTileContainerProps & { store: ViewStore };
 
 		const target = e.target as HTMLElement;
 
@@ -59,7 +60,8 @@ export class PageTileContainer extends React.Component<PageTileContainerProps> {
 			return;
 		}
 
-		const store = ViewStore.getInstance();
+		const { store } = this.props as PageTileContainerProps & { store: ViewStore };
+
 		const next =
 			store.getActiveView() === Types.AlvaView.Pages
 				? Types.AlvaView.PageDetail

--- a/src/container/pattern-list/pattern-item-container.tsx
+++ b/src/container/pattern-list/pattern-item-container.tsx
@@ -4,6 +4,7 @@ import {
 	PatternItemLabel,
 	PatternListItem
 } from '../../components';
+import * as MobxReact from 'mobx-react';
 import { Pattern } from '../../model';
 import * as React from 'react';
 import { ViewStore } from '../../store';
@@ -12,9 +13,11 @@ export interface PatternItemContainerContainerProps {
 	pattern: Pattern;
 }
 
+@MobxReact.inject('store')
+@MobxReact.observer
 export class PatternItemContainer extends React.Component<PatternItemContainerContainerProps> {
 	private handleDoubleClick(e: React.MouseEvent<HTMLElement>): void {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as PatternItemContainerContainerProps & { store: ViewStore };
 		const element = store.createElement({ pattern: this.props.pattern });
 
 		const getTargetElement = () => {
@@ -42,7 +45,7 @@ export class PatternItemContainer extends React.Component<PatternItemContainerCo
 	}
 
 	private handleDragStart(e: React.DragEvent<HTMLElement>): void {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as PatternItemContainerContainerProps & { store: ViewStore };
 
 		const element = store.createElement({ pattern: this.props.pattern, dragged: true });
 		store.addElement(element);

--- a/src/container/pattern-list/pattern-list-container.tsx
+++ b/src/container/pattern-list/pattern-list-container.tsx
@@ -5,10 +5,11 @@ import { PatternItemContainer } from './pattern-item-container';
 import * as React from 'react';
 import { ViewStore } from '../../store';
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class PatternListContainer extends React.Component {
 	public render(): JSX.Element | null {
-		const store = ViewStore.getInstance();
+		const { store } = this.props as { store: ViewStore };
 		const patternLibrary = store.getPatternLibrary();
 
 		if (!patternLibrary) {

--- a/src/container/property-list/property-list.tsx
+++ b/src/container/property-list/property-list.tsx
@@ -8,10 +8,12 @@ import { ViewStore } from '../../store';
 import * as Types from '../../model/types';
 import * as uuid from 'uuid';
 
+@MobxReact.inject('store')
 @MobxReact.observer
 export class PropertyListContainer extends React.Component {
 	public render(): React.ReactNode {
-		const selectedElement = ViewStore.getInstance().getSelectedElement();
+		const { store } = this.props as { store: ViewStore };
+		const selectedElement = store.getSelectedElement();
 
 		if (!selectedElement) {
 			return null;

--- a/src/electron/context-menus.ts
+++ b/src/electron/context-menus.ts
@@ -6,9 +6,7 @@ import { ViewStore } from '../store';
 import * as Types from '../model/types';
 import * as uuid from 'uuid';
 
-const store = ViewStore.getInstance();
-
-export function elementMenu(element: Element): void {
+export function elementMenu(element: Element, store: ViewStore): void {
 	const defaultPasteItems = [
 		{
 			label: 'Paste Below',

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -135,7 +135,7 @@ export function createMenu(ctx: MenuContext): void {
 								});
 
 								if (path) {
-									const sketchExporter = new SketchExporter();
+									const sketchExporter = new SketchExporter(ctx.store);
 									sketchExporter.execute(path);
 								}
 							}
@@ -156,7 +156,7 @@ export function createMenu(ctx: MenuContext): void {
 								});
 
 								if (path) {
-									const pdfExporter = new PdfExporter();
+									const pdfExporter = new PdfExporter(ctx.store);
 									pdfExporter.execute(path);
 								}
 							}
@@ -177,7 +177,7 @@ export function createMenu(ctx: MenuContext): void {
 								});
 
 								if (path) {
-									const pngExporter = new PngExporter();
+									const pngExporter = new PngExporter(ctx.store);
 									pngExporter.execute(path);
 								}
 							}
@@ -201,7 +201,7 @@ export function createMenu(ctx: MenuContext): void {
 								});
 
 								if (path) {
-									const htmlExporter = new HtmlExporter();
+									const htmlExporter = new HtmlExporter(ctx.store);
 									htmlExporter.execute(path);
 								}
 							}

--- a/src/electron/renderer.tsx
+++ b/src/electron/renderer.tsx
@@ -4,6 +4,7 @@ import { createMenu } from './create-menu';
 import { webFrame } from 'electron';
 import { ServerMessageType } from '../message';
 import * as Mobx from 'mobx';
+import * as MobxReact from 'mobx-react';
 import { PatternLibrary, Project } from '../model';
 import * as React from 'react';
 import * as ReactDom from 'react-dom';
@@ -15,7 +16,7 @@ import * as uuid from 'uuid';
 webFrame.setVisualZoomLevelLimits(1, 1);
 webFrame.setLayoutZoomLevelLimits(0, 0);
 
-const store = ViewStore.getInstance();
+const store = new ViewStore();
 
 Sender.send({
 	id: uuid.v4(),
@@ -302,7 +303,12 @@ Mobx.autorunAsync(() => {
 	}
 });
 
-ReactDom.render(React.createElement(App), document.getElementById('app'));
+ReactDom.render(
+	<MobxReact.Provider store={store}>
+		<App />
+	</MobxReact.Provider>,
+	document.getElementById('app')
+);
 
 // Disable drag and drop from outside the application
 document.addEventListener(

--- a/src/export/html-exporter.ts
+++ b/src/export/html-exporter.ts
@@ -8,12 +8,16 @@ import * as Types from '../model/types';
 
 export class HtmlExporter implements Types.Exporter {
 	public contents: Buffer;
+	private store: ViewStore;
+
+	public constructor(store: ViewStore) {
+		this.store = store;
+	}
 
 	public async execute(path: string): Promise<void> {
-		const store = ViewStore.getInstance();
-		const project = store.getProject();
+		const project = this.store.getProject();
 		const patternLibrary = project.getPatternLibrary();
-		const currentPage = store.getCurrentPage();
+		const currentPage = this.store.getCurrentPage();
 		const id = uuid.v4();
 
 		const componentScript = {

--- a/src/export/pdf-exporter.ts
+++ b/src/export/pdf-exporter.ts
@@ -9,6 +9,12 @@ import * as Types from '../model/types';
 export class PdfExporter implements Types.Exporter {
 	public contents: Buffer;
 
+	private store: ViewStore;
+
+	public constructor(store: ViewStore) {
+		this.store = store;
+	}
+
 	public execute(path: string): void {
 		const id = uuid.v4();
 		const initial = 'data:text/html;<html></html>';
@@ -20,7 +26,6 @@ export class PdfExporter implements Types.Exporter {
 		webview.webpreferences = 'useContentSize=yes, javascript=no';
 		document.body.insertBefore(webview, document.body.firstChild);
 
-		const store = ViewStore.getInstance();
 		let started;
 
 		// (1) Request HTML contents from preview
@@ -43,7 +48,7 @@ export class PdfExporter implements Types.Exporter {
 
 			const parsed = Url.parse(payload.location);
 
-			if (parsed.host !== `localhost:${store.getServerPort()}`) {
+			if (parsed.host !== `localhost:${this.store.getServerPort()}`) {
 				return;
 			}
 

--- a/src/export/png-exporter.ts
+++ b/src/export/png-exporter.ts
@@ -10,6 +10,12 @@ import * as Types from '../model/types';
 export class PngExporter implements Types.Exporter {
 	public contents: Buffer;
 
+	private store: ViewStore;
+
+	public constructor(store: ViewStore) {
+		this.store = store;
+	}
+
 	private async createPngExport(): Promise<Buffer> {
 		return new Promise<Buffer>(resolve => {
 			const id = uuid.v4();
@@ -21,7 +27,6 @@ export class PngExporter implements Types.Exporter {
 			webview.webpreferences = 'useContentSize=yes, javascript=no';
 			document.body.insertBefore(webview, document.body.firstChild);
 
-			const store = ViewStore.getInstance();
 			const scaleFactor = remote.screen.getPrimaryDisplay().scaleFactor;
 
 			let config;
@@ -45,7 +50,7 @@ export class PngExporter implements Types.Exporter {
 				const payload = message.payload;
 				const parsed = Url.parse(payload.location);
 
-				if (parsed.host !== `localhost:${store.getServerPort()}`) {
+				if (parsed.host !== `localhost:${this.store.getServerPort()}`) {
 					return;
 				}
 

--- a/src/export/sketch-exporter.ts
+++ b/src/export/sketch-exporter.ts
@@ -9,9 +9,15 @@ import * as Types from '../model/types';
 export class SketchExporter implements Types.Exporter {
 	public contents: Buffer;
 
+	private store: ViewStore;
+
+	public constructor(store: ViewStore) {
+		this.store = store;
+	}
+
 	public execute(path: string): void {
 		const id = uuid.v4();
-		const page = ViewStore.getInstance().getCurrentPage() as Page;
+		const page = this.store.getCurrentPage() as Page;
 		const artboardName = page.getName();
 		const pageName = page.getName();
 


### PR DESCRIPTION
Replace the previous `getInstance` singleton pattern with an injection added to the React Application via `Mobx.Provider`. This prepares the rearchitecting of the edit history to jump between complete state copies instead of specifying undo/redo commands for each edit type.