### PR TITLE
fix: restore paste inside element

### DIFF
--- a/src/electron/context-menus.ts
+++ b/src/electron/context-menus.ts
@@ -22,7 +22,7 @@ export function elementMenu(element: Element, store: ViewStore): void {
 		},
 		{
 			label: 'Paste Inside',
-			enabled: store.hasApplicableClipboardItem(),
+			enabled: store.hasApplicableClipboardItem() && element.acceptsChildren(),
 			click: () => {
 				Sender.send({
 					id: uuid.v4(),

--- a/src/electron/renderer.tsx
+++ b/src/electron/renderer.tsx
@@ -218,7 +218,7 @@ Sender.receive(message => {
 			break;
 		}
 		case ServerMessageType.PasteElementInside: {
-			store.executeElementPasteAfterById(message.payload);
+			store.executeElementPasteInsideById(message.payload);
 			break;
 		}
 		case ServerMessageType.Duplicate: {

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -389,7 +389,7 @@ export class ViewStore {
 		}
 
 		this.insertElementInside({ element: clipboardElement, targetElement: element });
-		this.setSelectedElement(element);
+		this.setSelectedElement(clipboardElement);
 		this.commit();
 
 		return element;


### PR DESCRIPTION
* Correctly paste inside a given element
* Correctly select the newly pasted element
* Disable "paste inside" if the current element does not accept children