### PR TITLE
fix: relax check for slot props

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -403,6 +403,14 @@ async function createWindow(): Promise<void> {
 						payload: undefined,
 						type: ServerMessageType.UnselectElement
 					});
+					break;
+				}
+				case PreviewMessageType.HighlightElement: {
+					Sender.send({
+						id: message.id,
+						payload: message.payload,
+						type: ServerMessageType.HighlightElement
+					});
 				}
 			}
 		} catch (err) {

--- a/src/electron/renderer.tsx
+++ b/src/electron/renderer.tsx
@@ -28,6 +28,14 @@ const id = `s${uuid
 (window as any)[id] = store;
 console.log(`Access ViewStore at ${id}`);
 
+window.addEventListener('keydown', e => {
+	store.setMetaDown(e.metaKey);
+});
+
+window.addEventListener('keyup', e => {
+	store.setMetaDown(false);
+});
+
 Sender.send({
 	id: uuid.v4(),
 	type: ServerMessageType.AppLoaded,
@@ -149,6 +157,13 @@ Sender.receive(message => {
 		}
 		case ServerMessageType.UnselectElement: {
 			store.unsetSelectedElement();
+			break;
+		}
+		case ServerMessageType.HighlightElement: {
+			const element = store.getElementById(message.payload.id);
+			if (element && (message.payload.metaDown || store.getMetaDown())) {
+				store.setHighlightedElement(element);
+			}
 		}
 	}
 });

--- a/src/message/message.ts
+++ b/src/message/message.ts
@@ -6,6 +6,7 @@ export enum PreviewMessageType {
 	ContentResponse = 'content-response',
 	ChangeHighlightedElement = 'change-highlighted-element',
 	ChangeSelectedElement = 'change-selected-element',
+	HighlightElement = 'highlight-element',
 	Reload = 'reload',
 	SelectElement = 'select-element',
 	SketchExportRequest = 'sketch-export-request',
@@ -47,6 +48,7 @@ export enum ServerMessageType {
 	ExportPDF = 'export-pdf',
 	ExportPNG = 'export-png',
 	ExportSketch = 'export-sketch',
+	HighlightElement = 'highlight-element',
 	Log = 'log',
 	OpenFileRequest = 'open-file-request',
 	OpenFileResponse = 'open-file-response',
@@ -106,6 +108,7 @@ export type ServerMessage =
 	| ExportPDF
 	| ExportPNG
 	| ExportSketch
+	| HighlightElement
 	| Log
 	| OpenFileRequest
 	| OpenFileResponse
@@ -176,6 +179,7 @@ export type ExportHTML = Envelope<ServerMessageType.ExportHTML, Types.ExportPayl
 export type ExportPDF = Envelope<ServerMessageType.ExportPDF, Types.ExportPayload>;
 export type ExportPNG = Envelope<ServerMessageType.ExportPNG, Types.ExportPayload>;
 export type ExportSketch = Envelope<ServerMessageType.ExportSketch, Types.ExportPayload>;
+export type HighlightElement = Envelope<ServerMessageType.HighlightElement, Types.PatternIdPayload>;
 export type NewFileRequest = EmptyEnvelope<ServerMessageType.CreateNewFileRequest>;
 export type NewFileResponse = Envelope<
 	ServerMessageType.CreateNewFileResponse,
@@ -196,7 +200,7 @@ export type PastePageElementBelow = Envelope<ServerMessageType.PasteElementBelow
 export type PastePageElementInside = Envelope<ServerMessageType.PasteElementInside, string>;
 export type Redo = EmptyEnvelope<ServerMessageType.Redo>;
 export type Save = Envelope<ServerMessageType.Save, Types.SavePayload>;
-export type SelectElement = Envelope<ServerMessageType.SelectElement, Types.SelectPayload>;
+export type SelectElement = Envelope<ServerMessageType.SelectElement, Types.PatternIdPayload>;
 export type SketchExportRequest = Envelope<
 	ServerMessageType.SketchExportRequest,
 	Types.SketchExportPayload

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -387,12 +387,14 @@ export interface RenderInit {
 	// tslint:disable-next-line:no-any
 	getSlots(slots: any, render: (props: any) => any): any;
 	onElementClick(e: MouseEvent, payload: { id: string }): void;
+	onElementMouseOver(e: MouseEvent, payload: { id: string | undefined }): void;
 	onElementSelect(e: MouseEvent, payload: { id: string }): void;
 	onOutsideClick(e: MouseEvent): void;
 }
 
-export interface SelectPayload {
+export interface PatternIdPayload {
 	id: string;
+	metaDown: boolean;
 }
 
 export enum ElementRole {

--- a/src/preview/preview-renderer.tsx
+++ b/src/preview/preview-renderer.tsx
@@ -143,6 +143,7 @@ export function render(init: Types.RenderInit, container: HTMLElement): void {
 		>
 			<PreviewApplication
 				highlight={highlight}
+				onElementMouseOver={init.onElementMouseOver}
 				onElementClick={init.onElementClick}
 				onOutsideClick={init.onOutsideClick}
 				onElementSelect={init.onElementSelect}
@@ -157,6 +158,7 @@ export function render(init: Types.RenderInit, container: HTMLElement): void {
 interface PreviewApplicationProps {
 	highlight: HighlightArea;
 	onElementClick: Types.RenderInit['onElementClick'];
+	onElementMouseOver: Types.RenderInit['onElementMouseOver'];
 	onElementSelect: Types.RenderInit['onElementSelect'];
 	onOutsideClick: Types.RenderInit['onOutsideClick'];
 	selection: SelectArea;
@@ -171,10 +173,12 @@ class PreviewApplication extends React.Component<PreviewApplicationProps> {
 	public constructor(props: PreviewApplicationProps) {
 		super(props);
 		this.handleClick = this.handleClick.bind(this);
+		this.handleMouseOver = this.handleMouseOver.bind(this);
 		this.handleResize = this.handleResize.bind(this);
 	}
 
 	public componentDidMount(): void {
+		document.addEventListener('mouseover', this.handleMouseOver);
 		document.addEventListener('click', this.handleClick);
 		window.addEventListener('resize', this.handleResize);
 
@@ -203,6 +207,7 @@ class PreviewApplication extends React.Component<PreviewApplicationProps> {
 	}
 
 	public componentWillUnmount(): void {
+		document.removeEventListener('mouseover', this.handleMouseOver);
 		document.removeEventListener('click', this.handleClick);
 		window.removeEventListener('resize', this.handleResize);
 
@@ -241,8 +246,16 @@ class PreviewApplication extends React.Component<PreviewApplicationProps> {
 		clickedIds.forEach(clickedId => this.props.onElementClick(e, { id: clickedId }));
 	}
 
+	private handleMouseOver(e: MouseEvent): void {
+		const id = getElementIdByNode(e.target as HTMLElement);
+		this.props.onElementMouseOver(e, { id });
+	}
+
 	private handleResize(): void {
-		window.requestAnimationFrame(() => this.updateSelection());
+		window.requestAnimationFrame(() => {
+			this.updateSelection();
+			this.updateHighlight();
+		});
 	}
 
 	public render(): JSX.Element | null {
@@ -459,7 +472,8 @@ class PreviewHighlight extends React.Component<PreviewHighlightProps> {
 					width: highlight.width,
 					height: highlight.height,
 					border: '2px solid #42BFFE',
-					opacity: highlight.opacity
+					opacity: highlight.opacity,
+					pointerEvents: 'none'
 				}}
 			/>
 		);


### PR DESCRIPTION
Fixes a bug where slots would not register correctly when the 
type of a children property can not be resolved by the typechecker.

* Assume `children` with any type are slots
* Allow `@slot` annotations
* Allow `@href` annotations