### PR TITLE
fix: disable text select on splash screen

### DIFF
--- a/src/components/splash-screen/index.tsx
+++ b/src/components/splash-screen/index.tsx
@@ -11,6 +11,8 @@ const StyledSplashScreen = styled.div`
 	justify-content: center;
 	padding: 0 ${PageInset.XL}px;
 	transform: translateY(-54px);
+	user-select: none;
+	cursor: default;
 `;
 
 const StyledLeftSection = styled.div`


### PR DESCRIPTION
Disable user-select of text on Splash Screen, so it feels like a desktop app.