### PR TITLE
fix: show collapse not on root elements

### DIFF
--- a/src/container/element-list/element-container.tsx
+++ b/src/container/element-list/element-container.tsx
@@ -4,6 +4,7 @@ import { ElementContentContainer } from './element-content-container';
 import * as MobxReact from 'mobx-react';
 import * as Model from '../../model';
 import * as React from 'react';
+import { ElementRole } from '../../model/types';
 import { ViewStore } from '../../store';
 
 export interface ElementContainerProps {
@@ -30,7 +31,9 @@ export class ElementContainer extends React.Component<ElementContainerProps> {
 				draggable={true}
 				dragging={store.getDragging()}
 				id={props.element.getId()}
-				mayOpen={props.element.acceptsChildren()}
+				mayOpen={
+					props.element.acceptsChildren() && props.element.getRole() !== ElementRole.Root
+				}
 				open={open}
 				onChange={AlvaUtil.noop}
 				placeholderHighlighted={props.element.getPlaceholderHighlighted()}


### PR DESCRIPTION
Because it does not make that much sense if you can collapse your entire page.