### PR TITLE
fix(typescript-react-analyzer): analyze number enums correctly

### DIFF
--- a/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
+++ b/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
@@ -216,7 +216,7 @@ function createEnumProperty(
 				? String(enumMember.initializer.getText())
 				: String(index);
 
-			const value = init.charAt(0) === '"' ? init.slice(1, -1) : parseInt(init);
+			const value = init.charAt(0) === '"' ? init.slice(1, -1) : parseInt(init, 10);
 
 			const name =
 				TypescriptUtils.getJsDocValueFromNode(enumMember, 'name') || enumMember.name.getText();

--- a/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
+++ b/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
@@ -216,7 +216,7 @@ function createEnumProperty(
 				? String(enumMember.initializer.getText())
 				: String(index);
 
-			const value = init.charAt(0) === '"' ? init.slice(1, -1) : init;
+			const value = init.charAt(0) === '"' ? init.slice(1, -1) : parseInt(init);
 
 			const name =
 				TypescriptUtils.getJsDocValueFromNode(enumMember, 'name') || enumMember.name.getText();

--- a/src/model/pattern-property/enum-property.ts
+++ b/src/model/pattern-property/enum-property.ts
@@ -123,7 +123,7 @@ export interface PatternEnumPropertyOptionInit {
 	id: string;
 	name: string;
 	ordinal: string;
-	value: string;
+	value: string | number;
 }
 
 export class PatternEnumPropertyOption {
@@ -131,7 +131,7 @@ export class PatternEnumPropertyOption {
 	@Mobx.observable private id: string;
 	@Mobx.observable private name: string;
 	@Mobx.observable private ordinal: string;
-	@Mobx.observable private value: string;
+	@Mobx.observable private value: string | number;
 
 	public constructor(init: PatternEnumPropertyOptionInit) {
 		this.id = init.id;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -199,7 +199,7 @@ export interface SerializedEnumOption {
 	id: string;
 	name: string;
 	ordinal: string;
-	value: string;
+	value: string | number;
 }
 
 export interface SerializedPatternNumberArrayProperty extends SerializedPropertyBase {


### PR DESCRIPTION
Number Enums were parsed as Strings. They are now parsed as numbers via parseInt.
The headline component from the designkit should now have working enums again.

Should be squashed into `fix: analyze number enums correctly`