### PR TITLE
fix: remove redundant event listeners

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -53,23 +53,7 @@ let projectPath: string | undefined;
 
 const userStore = new ElectronStore();
 
-async function createWindow(): Promise<void> {
-	const { width = 1280, height = 800 } = screen.getPrimaryDisplay().workAreaSize;
-
-	// Create the browser window.
-	win = new BrowserWindow({
-		width,
-		height,
-		minWidth: 780,
-		minHeight: 380,
-		titleBarStyle: 'hiddenInset',
-		backgroundColor: Color.Grey97,
-		title: 'Alva'
-	});
-
-	// and load the index.html of the app.
-	win.loadURL('data:text/html;charset=utf-8,' + encodeURI(RENDERER_DOCUMENT));
-
+(async () => {
 	// Cast getPort return type from PromiseLike<number> to Promise<number>
 	// to avoid async-promise tslint rule to produce errors here
 	const port = await (getPort({ port: 1879 }) as Promise<number>);
@@ -437,6 +421,24 @@ async function createWindow(): Promise<void> {
 			console.error(err);
 		}
 	});
+})();
+
+async function createWindow(): Promise<void> {
+	const { width = 1280, height = 800 } = screen.getPrimaryDisplay().workAreaSize;
+
+	// Create the browser window.
+	win = new BrowserWindow({
+		width,
+		height,
+		minWidth: 780,
+		minHeight: 380,
+		titleBarStyle: 'hiddenInset',
+		backgroundColor: Color.Grey97,
+		title: 'Alva'
+	});
+
+	// and load the index.html of the app.
+	win.loadURL('data:text/html;charset=utf-8,' + encodeURI(RENDERER_DOCUMENT));
 
 	// Open the DevTools.
 	// win.webContents.openDevTools();


### PR DESCRIPTION
Hello,

Thanks for all the effort you are putting in Alva and the given lightning talk at JSConf EU 2018.

I have been looking at Alva's code and realised there are some redundant listeners. So I thought I could contribute to it a little bit.

There is no open issue about this. So I hope it's not a problem that I am just trying to fix a thing I have found on my own without creating an issue here. 

The issue is; whenever a user closes and opens a window in Alva, listeners which are in `src/electron/main.ts` file were re-attached. Therefore, after closing & opening Alva window several times, the actions in listeners were executed as many as it's re-opened. Then if a user tries to open an existing Alva file, (s)he sees multiple "open file" dialog.

A screenshot when an existing Alva file is opened after I re-opened Alva's window five times;
![image](https://user-images.githubusercontent.com/1263419/41112679-f2ad8cd6-6a7f-11e8-8070-7367d6089202.png)

For the review; I would suggest reading the file. Because here, the change does not look like properly. What I have done is; I have taken the server creation and the listener out of `createWindow` and put it in an IIFE (since that part was async and there is no top-level async support) in order to avoid the redundant load and fix the application behaviour for user experience.