### PR TITLE
fix: stop committing openings of files in store

### DIFF
--- a/src/electron/renderer.tsx
+++ b/src/electron/renderer.tsx
@@ -71,8 +71,6 @@ Sender.receive(message => {
 					type: ServerMessageType.CheckLibraryRequest
 				});
 			}
-
-			store.commit();
 			break;
 		}
 		case ServerMessageType.CreateNewFileResponse: {
@@ -80,7 +78,6 @@ Sender.receive(message => {
 			const newProject = Project.from(message.payload.contents);
 			store.setProject(newProject);
 			app.setActiveView(Types.AlvaView.PageDetail);
-			store.commit();
 			break;
 		}
 		case ServerMessageType.Log: {


### PR DESCRIPTION
Aimed for #534, openings of an Alva file can be reverted with `undo`.

Therefore, I have removed `store.commit()` from `ServerMessageType.OpenFileResponse` and `ServerMessageType.CreateNewFileResponse` in order to ignore these kind of changes for history.