### PR TITLE
chore: explicitly configure typescript-styled-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,12 @@
         }
       }
     },
+    "@emmetio/extract-abbreviation": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz",
+      "integrity": "sha512-Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==",
+      "dev": true
+    },
     "@marionebl/react-docgen-typescript": {
       "version": "1.6.0-1",
       "resolved": "https://registry.npmjs.org/@marionebl/react-docgen-typescript/-/react-docgen-typescript-1.6.0-1.tgz",
@@ -2122,7 +2128,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6886,7 +6891,6 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -6908,8 +6912,7 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -6923,13 +6926,11 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6940,18 +6941,15 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -6986,8 +6984,7 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -7014,8 +7011,7 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -7124,7 +7120,6 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -7166,7 +7161,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7178,8 +7172,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -7242,13 +7235,11 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -7316,8 +7307,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -7366,8 +7356,7 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -7400,7 +7389,6 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -7449,8 +7437,7 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
@@ -7470,7 +7457,6 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -7501,7 +7487,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7511,7 +7496,6 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -7536,7 +7520,6 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -7586,8 +7569,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -9901,6 +9883,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
+    "jsonc-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-1.0.3.tgz",
+      "integrity": "sha512-hk/69oAeaIzchq/v3lS50PXuzn5O2ynldopMC+SWBql7J2WtdptfB9dy8Y7+Og5rPkTCpn83zTiO8FMcqlXJ/g==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -10465,8 +10453,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -15071,6 +15058,24 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
       "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
     },
+    "typescript-styled-plugin": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/typescript-styled-plugin/-/typescript-styled-plugin-0.6.3.tgz",
+      "integrity": "sha512-grdDFopKiknX3CFEX0jIe2SzR3Bj8m6qdRzPKgQ1cda237+UPNbgxnW36qz8oVczYRdyT57R4MBa0IcAt8Cf2A==",
+      "dev": true,
+      "requires": {
+        "typescript-template-language-service-decorator": "^1.2.0",
+        "vscode-css-languageservice": "^3.0.8",
+        "vscode-emmet-helper": "1.1.36",
+        "vscode-languageserver-types": "^3.6.0-next.1"
+      }
+    },
+    "typescript-template-language-service-decorator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-1.2.0.tgz",
+      "integrity": "sha512-rF0jrvpYn6Ec2jnxBHF1st/HEl84LV7od8872o82zHgKEU1vFhT4x6fvuLi5UD0gl2gKv3zSefG18DoeUHE7ig==",
+      "dev": true
+    },
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -15683,6 +15688,39 @@
           }
         }
       }
+    },
+    "vscode-css-languageservice": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.8.tgz",
+      "integrity": "sha512-3db4v/st2eT9fmKqwtgIl/mEq81wd5dQHBHswKLF4/QjpVoE0OzRq5iO8nppOcfSuLuCEr72C/cWmygMCSL9Rw==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-types": "^3.6.1",
+        "vscode-nls": "^3.2.1"
+      }
+    },
+    "vscode-emmet-helper": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-1.1.36.tgz",
+      "integrity": "sha512-MbGlzcY2NZPeF6drPEpSJbiBKUt6q1EhBjQX8DbQxyjdUFscAqb9Ke+62flRX0H1toimovd8Kl5cyhKV0IoZLw==",
+      "dev": true,
+      "requires": {
+        "@emmetio/extract-abbreviation": "^0.1.4",
+        "jsonc-parser": "^1.0.0",
+        "vscode-languageserver-types": "^3.6.0-next.1"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.1.tgz",
+      "integrity": "sha512-O8IBrxSBp2AJALIZBwT2Gd6gX67MMtwCwnfzT9T3QynE+dqikoj7x3kOb3fdIjd9hIoAB2yc38XcJJDw8H1cpw==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.2.tgz",
+      "integrity": "sha512-/Ur1+tgazwd51+ncRyoy0UIu4dvMdVXS9XMUULQlZIBoNGEwOhwEx9x+hHWoUjldMrOQ32t2CGKo0u6D4R6/hg==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "tempy": "0.2.1",
     "ts-jest": "22.4.2",
     "tslint": "5.9.1",
-    "typedoc": "0.11.1"
+    "typedoc": "0.11.1",
+    "typescript-styled-plugin": "0.6.3"
   },
   "dependencies": {
     "@brainly/html-sketchapp": "3.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,14 @@
 		"isolatedModules": false,
 		"jsx": "react",
 		"module": "commonjs",
+		"plugins": [
+			{
+				"name": "typescript-styled-plugin",
+				"lint": {
+					"unknownProperties": "ignore"
+				}
+			}
+		],
 		"lib": [
 			"es2017",
 			"dom"


### PR DESCRIPTION
Explicitly configure stylelint integration with TypeScript and styled-components. Also disable the `unknown-properties` rule to allow Webkit-only properties without producing warnings.