### PR TITLE
fix: unify drag image style and handling

### DIFF
--- a/src/container/element-drag-image.tsx
+++ b/src/container/element-drag-image.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import * as Components from '../components';
+import * as Model from '../model';
+
+const StyledElementDragImage = styled.div`
+	position: fixed;
+	top: 100vh;
+	background-color: ${Components.Color.White};
+	color: ${Components.Color.Black};
+	padding: 6px 18px;
+	border-radius: 3px;
+	font-size: 12px;
+	opacity: 1;
+`;
+
+export class ElementDragImage extends React.Component<{
+	element?: Model.Element;
+	innerRef(ref: HTMLElement): void;
+}> {
+	public render(): JSX.Element {
+		const { props } = this;
+
+		return (
+			<StyledElementDragImage innerRef={props.innerRef}>
+				{props.element && props.element.getName()}
+			</StyledElementDragImage>
+		);
+	}
+}

--- a/src/container/pattern-list/pattern-item-container.tsx
+++ b/src/container/pattern-list/pattern-item-container.tsx
@@ -1,9 +1,4 @@
-import {
-	PatternAnchor,
-	PatternItemDescription,
-	PatternItemLabel,
-	PatternListItem
-} from '../../components';
+import * as Components from '../../components';
 import * as MobxReact from 'mobx-react';
 import { Pattern } from '../../model';
 import * as React from 'react';
@@ -46,31 +41,24 @@ export class PatternItemContainer extends React.Component<PatternItemContainerCo
 
 	private handleDragStart(e: React.DragEvent<HTMLElement>): void {
 		const { store } = this.props as PatternItemContainerContainerProps & { store: ViewStore };
-
 		const element = store.createElement({ pattern: this.props.pattern, dragged: true });
 		store.addElement(element);
-
-		e.dataTransfer.effectAllowed = 'copy';
-
-		e.dataTransfer.setDragImage(
-			e.currentTarget.querySelector(`[${PatternAnchor.icon}]`) as Element,
-			12,
-			12
-		);
 	}
 
 	public render(): JSX.Element | null {
 		const { props } = this;
 		return (
-			<PatternListItem
+			<Components.PatternListItem
 				key={props.pattern.getId()}
 				draggable
 				onDoubleClick={e => this.handleDoubleClick(e)}
 				onDragStart={e => this.handleDragStart(e)}
 			>
-				<PatternItemLabel>{props.pattern.getName()}</PatternItemLabel>
-				<PatternItemDescription>{props.pattern.getDescription()}</PatternItemDescription>
-			</PatternListItem>
+				<Components.PatternItemLabel>{props.pattern.getName()}</Components.PatternItemLabel>
+				<Components.PatternItemDescription>
+					{props.pattern.getDescription()}
+				</Components.PatternItemDescription>
+			</Components.PatternListItem>
 		);
 	}
 }

--- a/src/container/pattern-list/pattern-list-container.tsx
+++ b/src/container/pattern-list/pattern-list-container.tsx
@@ -1,4 +1,5 @@
 import { Search, Space, SpaceSize } from '../../components';
+import { ElementDragImage } from '../element-drag-image';
 import * as MobxReact from 'mobx-react';
 import { PatternFolderContainer } from './pattern-folder-container';
 import { PatternItemContainer } from './pattern-item-container';
@@ -8,6 +9,15 @@ import { ViewStore } from '../../store';
 @MobxReact.inject('store')
 @MobxReact.observer
 export class PatternListContainer extends React.Component {
+	private dragImg: HTMLElement | null;
+
+	private handleDragStart(e: React.DragEvent<HTMLElement>): void {
+		if (this.dragImg) {
+			e.dataTransfer.effectAllowed = 'copy';
+			e.dataTransfer.setDragImage(this.dragImg, 75, 15);
+		}
+	}
+
 	public render(): JSX.Element | null {
 		const { store } = this.props as { store: ViewStore };
 		const patternLibrary = store.getPatternLibrary();
@@ -20,7 +30,7 @@ export class PatternListContainer extends React.Component {
 		const matches = patternLibrary.query(store.getPatternSearchTerm());
 
 		return (
-			<>
+			<div onDragStart={e => this.handleDragStart(e)}>
 				<Space sizeBottom={SpaceSize.XXS}>
 					<Search
 						placeholder="Search Library"
@@ -34,7 +44,11 @@ export class PatternListContainer extends React.Component {
 					matches={matches}
 					render={pattern => <PatternItemContainer key={pattern.getId()} pattern={pattern} />}
 				/>
-			</>
+				<ElementDragImage
+					element={store.getDraggedElement()}
+					innerRef={ref => (this.dragImg = ref)}
+				/>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
* Use the same drag image for drag operations from element and pattern list
* Use a React component to create the desired image.

<details>
<summary>Screencast</summary>

![drag-img](https://user-images.githubusercontent.com/4248851/41198890-02417c92-6c89-11e8-9baf-405536d7ce86.gif)



</details>