### PR TITLE
fix(electron): open file dialog always on top

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -35,10 +35,14 @@ const RENDERER_DOCUMENT = `<!doctype html>
 </html>`;
 
 const showOpenDialog = (options: Electron.OpenDialogOptions): Promise<string[]> =>
-	new Promise(resolve => dialog.showOpenDialog(options, resolve));
+	new Promise(resolve =>
+		dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), options, resolve)
+	);
 
 const showSaveDialog = (options: Electron.SaveDialogOptions): Promise<string | undefined> =>
-	new Promise(resolve => dialog.showSaveDialog(options, resolve));
+	new Promise(resolve =>
+		dialog.showSaveDialog(BrowserWindow.getFocusedWindow(), options, resolve)
+	);
 
 const readFile = Util.promisify(Fs.readFile);
 const writeFile = Util.promisify(Fs.writeFile);


### PR DESCRIPTION
Before, after opening the file open/save dialog you could click on the alva app in the background. That meant, that you had an opened file window in the background you couldn’t see any more.

This fix binds the file open/save dialog to the focussed window, so it is always on the top.