### PR TITLE
fix: make first action undo-able

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -88,6 +88,12 @@ const userStore = new ElectronStore();
 			case ServerMessageType.AppLoaded: {
 				const pathToOpen = projectPath || openedFile;
 
+				send({
+					id: uuid.v4(),
+					type: ServerMessageType.StartApp,
+					payload: String(port)
+				});
+
 				// Load one of either
 				// (1) last known file automatically in development
 				// (2) file passed to electron main process
@@ -107,12 +113,6 @@ const userStore = new ElectronStore();
 						});
 					}
 				}
-
-				send({
-					id: uuid.v4(),
-					type: ServerMessageType.StartApp,
-					payload: String(port)
-				});
 
 				break;
 			}

--- a/src/electron/renderer.tsx
+++ b/src/electron/renderer.tsx
@@ -48,7 +48,6 @@ Sender.receive(message => {
 		case ServerMessageType.StartApp: {
 			app.setState(Types.AppState.Started);
 			store.setServerPort(Number(message.payload));
-			store.commit();
 			break;
 		}
 		case ServerMessageType.OpenFileResponse: {
@@ -71,6 +70,8 @@ Sender.receive(message => {
 					type: ServerMessageType.CheckLibraryRequest
 				});
 			}
+
+			store.commit();
 			break;
 		}
 		case ServerMessageType.CreateNewFileResponse: {
@@ -78,6 +79,7 @@ Sender.receive(message => {
 			const newProject = Project.from(message.payload.contents);
 			store.setProject(newProject);
 			app.setActiveView(Types.AlvaView.PageDetail);
+			store.commit();
 			break;
 		}
 		case ServerMessageType.Log: {


### PR DESCRIPTION
Aimed for #555, the first action cannot be undone.

This issue helped me understand how the history works in the store. :)

So.. I think we don't have to keep/commit every change in the store. Instead, to make the first action undo-able, I have committed the state whenever a file is opened/created. Because it allows us to know the previous state of the current file that we can go back. Besides that, I have stopped committing the state in `ServerMessageType.StartApp`. Because that was having a role in making #534 possible.