### PR TITLE
chore: use patternplate cover as website mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.49.tgz",
-      "integrity": "sha1-A7O/B+uYIHLI6FHdLd1RECguYb8=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.51.tgz",
+      "integrity": "sha1-SLjtGDBwNMZiD2Q1FGUMoszAFlo=",
       "dev": true,
       "requires": {
         "core-js": "2.5.7",
@@ -846,17 +846,17 @@
       "dev": true
     },
     "@patternplate/api": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@patternplate/api/-/api-2.5.10.tgz",
-      "integrity": "sha1-KYkJiA9AgMUvKAmGN7MbvjIFQjo=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/api/-/api-2.5.18.tgz",
+      "integrity": "sha1-ZoGuRp728pehETuNtI6uCiL31Rs=",
       "dev": true,
       "requires": {
         "@marionebl/sander": "0.6.1",
-        "@patternplate/compiler": "2.5.9",
-        "@patternplate/load-config": "2.5.9",
-        "@patternplate/load-docs": "2.5.9",
-        "@patternplate/load-meta": "2.5.9",
-        "@patternplate/validate-config": "2.5.9",
+        "@patternplate/compiler": "2.5.18",
+        "@patternplate/load-config": "2.5.18",
+        "@patternplate/load-docs": "2.5.18",
+        "@patternplate/load-meta": "2.5.18",
+        "@patternplate/validate-config": "2.5.18",
         "aggregate-error": "1.0.0",
         "arson": "0.2.6",
         "chokidar": "1.7.0",
@@ -876,28 +876,57 @@
       },
       "dependencies": {
         "@patternplate/load-config": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.9.tgz",
-          "integrity": "sha1-SdRMNr54CPpiAPn5aJoF5sG3Yn0=",
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.18.tgz",
+          "integrity": "sha1-+v1BOPsO9sSvvbQbpIgi0/vOyuQ=",
           "dev": true,
           "requires": {
-            "@patternplate/render-default": "2.5.9",
+            "@patternplate/render-default": "2.5.18",
             "cosmiconfig": "3.1.0",
             "resolve-from": "4.0.0"
           }
         },
-        "@patternplate/load-meta": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.9.tgz",
-          "integrity": "sha1-CGNkkEvEKEMLXDzhqAkgXKyvW/w=",
+        "@patternplate/load-doc": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-doc/-/load-doc-2.5.18.tgz",
+          "integrity": "sha1-Wuk/ElGR/HM828rheZ0yYYusaI4=",
           "dev": true,
           "requires": {
             "@marionebl/sander": "0.6.1",
-            "@patternplate/load-doc": "2.5.9",
-            "@patternplate/load-manifest": "2.5.9",
+            "globby": "6.1.0"
+          }
+        },
+        "@patternplate/load-manifest": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-manifest/-/load-manifest-2.5.18.tgz",
+          "integrity": "sha1-wuoqDjLzZvTDTlaN9KaCnmG9omg=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "load-json-file": "4.0.0"
+          }
+        },
+        "@patternplate/load-meta": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.18.tgz",
+          "integrity": "sha1-VQ4nB7VpazI8F587W+SUe6UH5Vc=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "@patternplate/load-doc": "2.5.18",
+            "@patternplate/load-manifest": "2.5.18",
             "globby": "6.1.0",
             "load-source-map": "1.0.0",
             "p-filter": "1.0.0"
+          }
+        },
+        "@patternplate/render-default": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/render-default/-/render-default-2.5.18.tgz",
+          "integrity": "sha1-R+rXWmfeL45oW5Ife7XV8bJ5A3Y=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
           }
         },
         "anymatch": {
@@ -1076,20 +1105,20 @@
       }
     },
     "@patternplate/cli": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@patternplate/cli/-/cli-2.5.11.tgz",
-      "integrity": "sha1-PNBYBhIatRlHbMogakMCRt65fxI=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/cli/-/cli-2.5.18.tgz",
+      "integrity": "sha1-++rk+Ut8LR3pcOqGkuiICSlV7bA=",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.0.0-beta.49",
+        "@babel/runtime": "7.0.0-beta.51",
         "@marionebl/sander": "0.6.1",
-        "@patternplate/client": "2.5.11",
-        "@patternplate/compiler": "2.5.9",
-        "@patternplate/create-default": "2.5.9",
-        "@patternplate/load-config": "2.5.9",
-        "@patternplate/load-docs": "2.5.9",
-        "@patternplate/load-meta": "2.5.9",
-        "@patternplate/validate-config": "2.5.9",
+        "@patternplate/client": "2.5.18",
+        "@patternplate/compiler": "2.5.18",
+        "@patternplate/create-default": "2.5.18",
+        "@patternplate/load-config": "2.5.18",
+        "@patternplate/load-docs": "2.5.18",
+        "@patternplate/load-meta": "2.5.18",
+        "@patternplate/validate-config": "2.5.18",
         "arson": "0.2.6",
         "chalk": "2.4.1",
         "command-exists": "1.2.6",
@@ -1110,28 +1139,57 @@
       },
       "dependencies": {
         "@patternplate/load-config": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.9.tgz",
-          "integrity": "sha1-SdRMNr54CPpiAPn5aJoF5sG3Yn0=",
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.18.tgz",
+          "integrity": "sha1-+v1BOPsO9sSvvbQbpIgi0/vOyuQ=",
           "dev": true,
           "requires": {
-            "@patternplate/render-default": "2.5.9",
+            "@patternplate/render-default": "2.5.18",
             "cosmiconfig": "3.1.0",
             "resolve-from": "4.0.0"
           }
         },
-        "@patternplate/load-meta": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.9.tgz",
-          "integrity": "sha1-CGNkkEvEKEMLXDzhqAkgXKyvW/w=",
+        "@patternplate/load-doc": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-doc/-/load-doc-2.5.18.tgz",
+          "integrity": "sha1-Wuk/ElGR/HM828rheZ0yYYusaI4=",
           "dev": true,
           "requires": {
             "@marionebl/sander": "0.6.1",
-            "@patternplate/load-doc": "2.5.9",
-            "@patternplate/load-manifest": "2.5.9",
+            "globby": "6.1.0"
+          }
+        },
+        "@patternplate/load-manifest": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-manifest/-/load-manifest-2.5.18.tgz",
+          "integrity": "sha1-wuoqDjLzZvTDTlaN9KaCnmG9omg=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "load-json-file": "4.0.0"
+          }
+        },
+        "@patternplate/load-meta": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.18.tgz",
+          "integrity": "sha1-VQ4nB7VpazI8F587W+SUe6UH5Vc=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "@patternplate/load-doc": "2.5.18",
+            "@patternplate/load-manifest": "2.5.18",
             "globby": "6.1.0",
             "load-source-map": "1.0.0",
             "p-filter": "1.0.0"
+          }
+        },
+        "@patternplate/render-default": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/render-default/-/render-default-2.5.18.tgz",
+          "integrity": "sha1-R+rXWmfeL45oW5Ife7XV8bJ5A3Y=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
           }
         },
         "ansi-regex": {
@@ -1263,15 +1321,15 @@
       }
     },
     "@patternplate/client": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@patternplate/client/-/client-2.5.11.tgz",
-      "integrity": "sha1-rB99rMfDeY/ABd794+sMcVkwLik=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/client/-/client-2.5.18.tgz",
+      "integrity": "sha1-4SGcG1RxtEXgyO0sYResVG6J1Hc=",
       "dev": true,
       "requires": {
-        "@patternplate/api": "2.5.10",
-        "@patternplate/load-config": "2.5.9",
-        "@patternplate/load-docs": "2.5.9",
-        "@patternplate/load-meta": "2.5.9",
+        "@patternplate/api": "2.5.18",
+        "@patternplate/load-config": "2.5.18",
+        "@patternplate/load-docs": "2.5.18",
+        "@patternplate/load-meta": "2.5.18",
         "buble": "0.19.3",
         "cors": "2.8.4",
         "express": "4.16.3",
@@ -1284,25 +1342,60 @@
       },
       "dependencies": {
         "@patternplate/load-config": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.9.tgz",
-          "integrity": "sha1-SdRMNr54CPpiAPn5aJoF5sG3Yn0=",
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.18.tgz",
+          "integrity": "sha1-+v1BOPsO9sSvvbQbpIgi0/vOyuQ=",
           "dev": true,
           "requires": {
-            "@patternplate/render-default": "2.5.9",
+            "@patternplate/render-default": "2.5.18",
             "cosmiconfig": "3.1.0",
             "resolve-from": "4.0.0"
           }
         },
-        "@patternplate/load-meta": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.9.tgz",
-          "integrity": "sha1-CGNkkEvEKEMLXDzhqAkgXKyvW/w=",
+        "@patternplate/load-doc": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-doc/-/load-doc-2.5.18.tgz",
+          "integrity": "sha1-Wuk/ElGR/HM828rheZ0yYYusaI4=",
           "dev": true,
           "requires": {
             "@marionebl/sander": "0.6.1",
-            "@patternplate/load-doc": "2.5.9",
-            "@patternplate/load-manifest": "2.5.9",
+            "globby": "6.1.0"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+              "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+              "dev": true,
+              "requires": {
+                "array-union": "1.0.2",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "@patternplate/load-manifest": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-manifest/-/load-manifest-2.5.18.tgz",
+          "integrity": "sha1-wuoqDjLzZvTDTlaN9KaCnmG9omg=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "load-json-file": "4.0.0"
+          }
+        },
+        "@patternplate/load-meta": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-meta/-/load-meta-2.5.18.tgz",
+          "integrity": "sha1-VQ4nB7VpazI8F587W+SUe6UH5Vc=",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "@patternplate/load-doc": "2.5.18",
+            "@patternplate/load-manifest": "2.5.18",
             "globby": "6.1.0",
             "load-source-map": "1.0.0",
             "p-filter": "1.0.0"
@@ -1322,20 +1415,29 @@
               }
             }
           }
+        },
+        "@patternplate/render-default": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/render-default/-/render-default-2.5.18.tgz",
+          "integrity": "sha1-R+rXWmfeL45oW5Ife7XV8bJ5A3Y=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
         }
       }
     },
     "@patternplate/compiler": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/compiler/-/compiler-2.5.9.tgz",
-      "integrity": "sha1-KTpsrvUsbi6ZYuFmIIbWNzWFK4w=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/compiler/-/compiler-2.5.18.tgz",
+      "integrity": "sha1-7a/iJk1wWTMd7vhRatywkOtCzNw=",
       "dev": true,
       "requires": {
-        "@patternplate/cover-client": "2.5.9",
-        "@patternplate/demo-client": "2.5.9",
-        "@patternplate/load-config": "2.5.9",
-        "@patternplate/probe-client": "2.5.9",
-        "@patternplate/webpack-entry": "2.5.9",
+        "@patternplate/cover-client": "2.5.18",
+        "@patternplate/demo-client": "2.5.18",
+        "@patternplate/load-config": "2.5.18",
+        "@patternplate/probe-client": "2.5.18",
+        "@patternplate/webpack-entry": "2.5.18",
         "css-loader": "0.28.11",
         "html-loader": "0.5.5",
         "loader-utils": "1.1.0",
@@ -1348,34 +1450,43 @@
       },
       "dependencies": {
         "@patternplate/load-config": {
-          "version": "2.5.9",
-          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.9.tgz",
-          "integrity": "sha1-SdRMNr54CPpiAPn5aJoF5sG3Yn0=",
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/load-config/-/load-config-2.5.18.tgz",
+          "integrity": "sha1-+v1BOPsO9sSvvbQbpIgi0/vOyuQ=",
           "dev": true,
           "requires": {
-            "@patternplate/render-default": "2.5.9",
+            "@patternplate/render-default": "2.5.18",
             "cosmiconfig": "3.1.0",
             "resolve-from": "4.0.0"
+          }
+        },
+        "@patternplate/render-default": {
+          "version": "2.5.18",
+          "resolved": "https://registry.npmjs.org/@patternplate/render-default/-/render-default-2.5.18.tgz",
+          "integrity": "sha1-R+rXWmfeL45oW5Ife7XV8bJ5A3Y=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
           }
         }
       }
     },
     "@patternplate/cover-client": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/cover-client/-/cover-client-2.5.9.tgz",
-      "integrity": "sha1-Bp5yLSHGJinLfCbVNs+nnzMVD3g=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/cover-client/-/cover-client-2.5.18.tgz",
+      "integrity": "sha1-fFskiWcg+Rk4Qs4XpocVLQK7PEo=",
       "dev": true
     },
     "@patternplate/create-default": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/create-default/-/create-default-2.5.9.tgz",
-      "integrity": "sha1-Vul5NmvRpvrLxRJD5WA8WwN1UPc=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/create-default/-/create-default-2.5.18.tgz",
+      "integrity": "sha1-aI8zJc4YrQ4oOXGw9PSZAhd798I=",
       "dev": true
     },
     "@patternplate/demo-client": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/demo-client/-/demo-client-2.5.9.tgz",
-      "integrity": "sha1-p6KKbVHXZTvLFX6I6xrPJ0+XMX8=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/demo-client/-/demo-client-2.5.18.tgz",
+      "integrity": "sha1-aN/HtnvJSXhiP29dMf6OY+OpECs=",
       "dev": true,
       "requires": {
         "iframe-resizer": "3.6.1"
@@ -1425,9 +1536,9 @@
       }
     },
     "@patternplate/load-docs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/load-docs/-/load-docs-2.5.9.tgz",
-      "integrity": "sha1-M9p3dpmMD9JxBccSd0U9nbWJFQE=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/load-docs/-/load-docs-2.5.18.tgz",
+      "integrity": "sha1-dwPvONZVas4tFmMsSNi/ZzMJYdA=",
       "dev": true,
       "requires": {
         "@marionebl/sander": "0.6.1",
@@ -1491,12 +1602,12 @@
       }
     },
     "@patternplate/probe-client": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/probe-client/-/probe-client-2.5.9.tgz",
-      "integrity": "sha1-Nlv+wDs7Bc1+Gk4V4D0LR4LEuyc=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/probe-client/-/probe-client-2.5.18.tgz",
+      "integrity": "sha1-mBm5XQ82sSl8P9BH5+Luxkf2HXI=",
       "dev": true,
       "requires": {
-        "@patternplate/websocket-client": "2.5.9",
+        "@patternplate/websocket-client": "2.5.18",
         "arson": "0.2.6",
         "iframe-resizer": "3.6.1"
       }
@@ -1536,18 +1647,18 @@
       }
     },
     "@patternplate/validate-config": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/validate-config/-/validate-config-2.5.9.tgz",
-      "integrity": "sha1-KmChGrAJC2CcGv1DxxTX4xXJDtQ=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/validate-config/-/validate-config-2.5.18.tgz",
+      "integrity": "sha1-ecJzpgv8IZT695WvufFBj2zcSnc=",
       "dev": true,
       "requires": {
         "@webpack-contrib/schema-utils": "1.0.0-beta.0"
       }
     },
     "@patternplate/webpack-entry": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/webpack-entry/-/webpack-entry-2.5.9.tgz",
-      "integrity": "sha1-lTgvaJo8H+rk6JyiTw67eMrRZ+I=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/webpack-entry/-/webpack-entry-2.5.18.tgz",
+      "integrity": "sha1-qQkbtVdRP6x/o/uU/9xL/hY1MVc=",
       "dev": true,
       "requires": {
         "glob-parent": "3.1.0",
@@ -1581,9 +1692,9 @@
       }
     },
     "@patternplate/websocket-client": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/@patternplate/websocket-client/-/websocket-client-2.5.9.tgz",
-      "integrity": "sha1-jTPXGKHzKQ8s6xgCAtKbR+t7VbY=",
+      "version": "2.5.18",
+      "resolved": "https://registry.npmjs.org/@patternplate/websocket-client/-/websocket-client-2.5.18.tgz",
+      "integrity": "sha1-ccS6kUE5FEKZ0LQ9+LGJx1FMx5U=",
       "dev": true
     },
     "@types/body-parser": {
@@ -1979,7 +2090,7 @@
       "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.0",
+        "ajv": "6.5.1",
         "ajv-keywords": "3.1.0",
         "chalk": "2.4.1",
         "strip-ansi": "4.0.0",
@@ -1988,14 +2099,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
-          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "2.0.1",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
+            "json-schema-traverse": "0.4.1",
             "uri-js": "4.2.2"
           }
         },
@@ -2035,6 +2146,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "punycode": {
@@ -2485,7 +2602,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000847",
+        "caniuse-db": "1.0.30000853",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -3116,7 +3233,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000847",
+        "caniuse-db": "1.0.30000853",
         "electron-to-chromium": "1.3.48"
       }
     },
@@ -3435,15 +3552,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000847",
+        "caniuse-db": "1.0.30000853",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000847",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000847.tgz",
-      "integrity": "sha1-/0BypUaICf7ArprDtANe+JHlsUQ=",
+      "version": "1.0.30000853",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000853.tgz",
+      "integrity": "sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -4986,7 +5103,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.44"
+        "es5-ext": "0.10.45"
       }
     },
     "dargs": {
@@ -6164,9 +6281,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.44",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
-      "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -6181,7 +6298,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.44",
+        "es5-ext": "0.10.45",
         "es6-symbol": "3.1.1"
       }
     },
@@ -6198,7 +6315,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.44"
+        "es5-ext": "0.10.45"
       }
     },
     "es6-templates": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@commitlint/config-conventional": "6.1.3",
     "@commitlint/prompt-cli": "6.1.3",
     "@commitlint/travis-cli": "6.1.3",
-    "@patternplate/cli": "2.5.11",
+    "@patternplate/cli": "2.5.18",
     "@patternplate/render-styled-components": "2.1.6",
     "@types/chokidar": "1.7.5",
     "@types/deep-assign": "0.1.1",

--- a/patternplate.config.js
+++ b/patternplate.config.js
@@ -10,6 +10,7 @@ const logo = `
 `;
 
 module.exports = {
+	cover: './website',
 	docs: [
 		'*.md',
 		'docs/*.md'

--- a/website/content.html
+++ b/website/content.html
@@ -1,0 +1,235 @@
+<section class="section hero dark">
+	<div class="wrapper left">
+		<div class="hero-links">
+			<a href="https://github.com/meetalva/alva" target="_blank" class="hero-github" title="Alva on Github">
+				<img src="https://media.meetalva.io/github.svg" role="presentation" alt=""> Alva on Github
+			</a>
+			<a href="https://twitter.com/meetalva" target="_blank" title="Alva on Github">@meetalva on Twitter</a>
+		</div>
+		<h1>
+			<strong>Meet Alva,</strong>
+			<br> a radically new
+			<u>digital design tool</u> built for cross-functional product teams.</h1>
+		<p>Alva lets you design interactive products based on the same components your engineers are using for production websites.
+			But, our mission goes way further. And guess what – we are entirely
+			<a href="https://github.com/meetalva" target="_blank">open source</a>.</p>
+		<a id="download-btn" class="button js-download-button" href="https://github.com/meetalva/alva/releases/latest">Download Alva</a>
+		<a href="https://github.com/meetalva/alva" target="_blank" class="hero-github">
+			<img src="https://media.meetalva.io/github.svg" alt="" role="presentation">
+		</a>
+		<p class="small-copy">This is an early alpha version. Feel free to try out, but we are still working hard on better support for external component
+			libraries.</p>
+	</div>
+</section>
+
+<section class="section application">
+	<img src="https://media.meetalva.io/application.png">
+</section>
+
+<section class="section mail">
+	<h2>Stay tuned</h2>
+	<p>Alva is a work-in-progress, and constantly evolving. Sign up with your email to be the first in line when we announce new
+		features. </p>
+	<!-- Begin MailChimp Signup Form -->
+	<div id="mc_embed_signup">
+		<form action="https://alva.us17.list-manage.com/subscribe/post?u=8f07560758ff52583a4f34f45&amp;id=d598cf405b" method="post"
+		 id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate form" target="_blank" novalidate>
+			<div id="mc_embed_signup_scroll">
+				<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="Email address" required>
+				<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+				<div style="position: absolute; left: -5000px;" aria-hidden="true">
+					<input type="text" name="b_8f07560758ff52583a4f34f45_d598cf405b" tabindex="-1" value="">
+				</div>
+				<input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button inverted submit">
+			</div>
+		</form>
+	</div>
+	<!--End mc_embed_signup-->
+</section>
+
+<section class="section blue invert">
+	<div class="wrapper left">
+		<h2>Design and engineering, joined together</h2>
+		<p>As a designer, you start with a minimal set of web components which are enhanced by importing new components as placeholder
+			images. Based on that, an engineer can start writing the component as real code and replace all the placeholder components.</p>
+		<section class="feature-tiles" role="presentation" aria-hidden="true">
+			<div class="feature">
+				<div class="tile">
+					<img src="https://media.meetalva.io/wireframe.png" alt="" />
+				</div>
+				<p class="small-copy">
+					Wireframe
+				</p>
+			</div>
+			<div class="feature">
+				<div class="tile">
+					<img src="https://media.meetalva.io/design.png" alt="" />
+				</div>
+				<p class="small-copy">
+					Design
+				</p>
+			</div>
+			<div class="feature">
+				<div class="tile">
+					<img src="https://media.meetalva.io/code.png" alt="" />
+				</div>
+				<p class="small-copy">
+					Design &amp; Code
+				</p>
+			</div>
+		</section>
+	</div>
+</section>
+
+<section class="section source">
+	<div class="wrapper">
+		<h2>Cross-functional single source of truth</h2>
+		<p>Instead of creating a separate static component library for Sketch, Photoshop and all the other tools, you can start building
+			your layouts and design with the very same components that your engineers use for the production website.</p>
+
+		<img src="https://media.meetalva.io/components.png" class="source-image" alt="" role="presentation">
+
+		<p>Basically, you share the component library with your engineers so that everyone has the latest version everywhere, everytime.</p>
+		<p class="small-copy">We are starting with React and certain
+			<a href="https://github.com/meetalva/alva#pattern-requirements-and-configuration"
+			 target="_blank">library requirements</a>, but we plan to be platform-agnostic in the future.</p>
+	</div>
+</section>
+
+<section class="section features invert">
+	<div class="wrapper">
+		<h2>Bringing web technology into web design</h2>
+		<p>A website is more than a plain fixed-size drawing canvas, where you can position rectangles, circles and text wherever
+			you want to. Responsive design doesn’t mean to have just three different viewports designed. And interaction is not only
+			connecting to static screens with a transition. It can be way more.</p>
+
+		<div class="features-application">
+			<div class="features-application-item">
+				<h4>Page elements</h4>
+				<p>On the left side are all the components you are using on your page. You can rearrange them or nest them.</p>
+			</div>
+
+			<div class="features-application-item">
+				<h4>Responsive</h4>
+				<p>Every viewport counts. You can easily adjust the preview viewport to test your design on every possible size.</p>
+			</div>
+
+			<div class="features-application-item">
+				<h4>Interactive</h4>
+				<p>The web is interactive, so we should design interactively, too. Alva enables you to go beyond static screens.</p>
+				<div class="badge">Coming soon</div>
+			</div>
+
+			<img src="https://media.meetalva.io/application.png" class="features-application-image">
+		</div>
+
+		<div class="features-additional">
+			<img src="https://media.meetalva.io/icon-customcode.png" aria-hidden="true" alt="" role="presentation">
+			<h3>Custom code integration</h3>
+			<p>If you’d like to implement custom logic or anything else code-based, you can insert custom code anywhere. So Designers
+				don’t have to code. But they are able to.</p>
+			<div class="badge">Coming soon</div>
+		</div>
+
+		<div class="features-additional">
+			<img src="https://media.meetalva.io/icon-livedata.png" aria-hidden="true" alt="" role="presentation">
+			<h3>Prototype design with live data</h3>
+			<p>You want to translate your designs into a dozen of languages? Or want to connect to real data? Don’t worry, Alva supports
+				that.
+			</p>
+			<div class="badge">Coming soon</div>
+		</div>
+	</div>
+</section>
+
+<section class="section contribute">
+	<div class="wrapper">
+		<h2 id="be-part-of-the-future-of-design">Be part of shaping the future of design</h2>
+		<p>Help us taking Alva to the next level with your design expertise, product management insights or engineering skills. Our
+			next features, bugs and the roadmap are fully open. Feel free to add issues, start pull requests or let us discuss what
+			should be next.</p>
+
+		<a class="button" href="./doc/README" target="_blank" title="Learn how to use Alva">Learn how to use Alva</a>
+		<br>
+		<a class="contribute-mail" href="mailto:hey@meetalva.io" title="Send us an Email">or send us an Email</a>
+	</div>
+</section>
+
+<section class="section about">
+	<div class="wrapper">
+		<h2>The story behind Alva</h2>
+		<p>»Alva« is the middle name of Thomas Alva Edison, who made electricity available to the public. And in Latin, »Alva« means
+			Wisdom. We started Alva in August 2017 as an initiative at
+			<a href="https://sinnerschrader.com" target="_blank">SinnerSchrader</a> and since then a quite small, but very powerful product design and engineering team is working hard
+			on building and evolving the Alva app and its ecosystem. </p>
+
+		<h3>Our core team</h3>
+		<div class="about-people">
+			<a class="about-people-item" href="https://github.com/Alexpeschel" target="_blank">
+				<h4>Alexander Peschel</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/Jumace" target="_blank">
+				<h4>Julian Cebulla</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/faselbaum" target="_blank">
+				<h4>Julius Walther</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/LKuechler" target="_blank">
+				<h4>Lasse Küchler</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/marionebl" target="_blank">
+				<h4>Mario Nebl</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/markusoelhafen" target="_blank">
+				<h4>Markus Ölhafen</h4>
+				<p>Product Design</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/Palmaswell" target="_blank">
+				<h4>Mauricio Palma</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/TheReincarnator" target="_blank">
+				<h4>Thomas Jacob</h4>
+				<p>Product Engineering</p>
+			</a>
+
+			<a class="about-people-item" href="https://github.com/tilmx" target="_blank">
+				<h4>Tilman Frick</h4>
+				<p>Product Lead</p>
+			</a>
+		</div>
+
+		<p>
+			<br>Special thanks to Holger Blank, Yuri Ziebell, Philipp von Essen, Stefan Förster and Felicitas Kugland. And we are proud
+			of so many more
+			<a href="https://github.com/meetalva/alva/graphs/contributors" target="_blank">contributors on Github</a>!</p>
+	</div>
+
+	<div class="social">
+		<a class="social-item twitter" href="https://twitter.com/home?status=Meet%20Alva,%20a%20radically%20new%20open%20source%20design%20tool%20built%20for%20cross-functional%20product%20teams.%20%40meetalva%20https%3A//meetalva.io/"
+		 target="_blank">Tweet about Alva</a>
+		<a class="social-item facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A//meetalva.io/" target="_blank">Share on Facebook</a>
+	</div>
+</section>
+
+<section class="section footer">
+	<a href="mailto:hey@meetalva.io" title="Send us an Email">hey@meetalva.io</a>
+	<br>
+	<br> Proudly powered by
+	<a href="https://sinnerschrader.com/" target="_blank">SinnerSchrader</a>
+	<br>
+	<a class="legallink" href="/legalnotice.html" target="_blank">Legal notice</a>
+	<a class="legallink" href="/privacypolicy.html" target="_blank">Privacy policy</a>
+</section>

--- a/website/head.html
+++ b/website/head.html
@@ -1,0 +1,16 @@
+<meta charset="UTF-8">
+<title>Meet Alva</title>
+<meta property="og:type" content="website" />
+<meta property="og:description" content="A radically new open source design tool built for cross-functional product teams." />
+<meta property="og:image" content="https://meetalva.io/images/alva-og_img.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@meetalva" />
+<meta name="twitter:title" content="Meet Alva" />
+<meta name="twitter:description" content="A radically new open source design tool built for cross-functional product teams." />
+<meta name="twitter:image" content="https://meetalva.io/images/alva-og_img.png" />
+<meta name="language" content="en" />
+<meta name="description" content="Alva is a radically new open source design tool built for cross-functional product teams. You can design with the same components your engineers are using for production." />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+<link rel="icon" href="https://media.meetalva.io/icon48.png" sizes="48x48" />
+<link rel="icon" href="https://media.meetalva.io/icon96.png" sizes="96x96" />
+<link rel="icon" href="https://media.meetalva.io/icon192.png" sizes="192x192" />

--- a/website/index.js
+++ b/website/index.js
@@ -1,0 +1,17 @@
+const content = require('./content.html');
+const css = require('./website.css');
+const head = require('./head.html');
+const js = require('raw-loader!./website.js');
+
+module.exports = {
+	css: () => css,
+	head: () => head,
+	html: () => content,
+	js: () => js,
+	render: input => ({
+		css: input.css(),
+		head: input.head(),
+		html: input.html(),
+		js: input.js()
+	})
+};

--- a/website/website.css
+++ b/website/website.css
@@ -1,0 +1,665 @@
+.font-light {
+	font-weight: 200;
+}
+
+.font-regular {
+	font-weight: 400;
+}
+
+.font-medium {
+	font-weight: 500;
+}
+
+html,
+body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	font-family: 'Helvetica Neue', 'Arial', sans-serif;
+	font-weight: 400;
+	font-size: 16px;
+	background-color: #151518;
+	color: #626262;
+	line-height: 1.5;
+	-webkit-font-smoothing: antialiased;
+}
+
+body {
+	height: auto;
+	background-color: white;
+}
+
+h1 {
+	font-size: 7rem;
+	color: #151518;
+	font-weight: 500;
+}
+
+.legal h1 {
+	font-size: 4rem;
+	font-weight: 500;
+}
+.legal h2 {
+	font-size: 2rem;
+	font-weight: 500;
+}
+
+@media only screen and (max-width: 959px) {
+	h1 {
+		font-size: 4rem;
+	}
+}
+
+@media only screen and (max-width: 540px) {
+	h1 {
+		font-size: 3rem;
+	}
+}
+
+h2 {
+	font-size: 4rem;
+	color: #151518;
+	font-weight: 500;
+	line-height: 1.3;
+	margin: 2rem 0;
+}
+
+@media only screen and (max-width: 540px) {
+	h2 {
+		font-size: 2.5rem;
+	}
+}
+
+h3 {
+	font-size: 1.75rem;
+	color: #151518;
+	font-weight: 500;
+}
+
+h4 {
+	font-size: 1.25rem;
+	color: #151518;
+	font-weight: 500;
+	margin: 0;
+}
+
+a {
+	text-decoration: underline;
+	color: inherit;
+	transition: all 0.3s;
+}
+
+a:hover {
+	text-decoration: none;
+	opacity: 0.8;
+}
+
+p {
+	font-size: 1rem;
+	line-height: 1.6;
+	color: inherit;
+}
+
+p.small-copy {
+	font-size: 13px;
+}
+
+.form {
+	margin-top: 3rem;
+	margin-bottom: 2rem;
+	justify-content: center;
+}
+
+input[type='email'] {
+	box-sizing: border-box;
+	display: block;
+	margin: 0 auto;
+	max-width: 420px;
+	min-width: 300px;
+	padding: 15px;
+	height: 50px;
+	outline: 0;
+	color: #999999;
+	font-size: inherit;
+	border: 1px solid #0070d6;
+	border-radius: 3px;
+	-webkit-appearance: none;
+}
+
+input[type='email'] ~ .button {
+	box-sizing: border-box;
+	height: 50px;
+	margin-top: 15px;
+	border: 0;
+	border-radius: 3px;
+	cursor: pointer;
+}
+
+input[type='email'] ~ .button:hover {
+	opacity: 1;
+}
+
+@media (min-width: 422px) {
+	input[type='email'] {
+		display: inline-block;
+		border-radius: 3px 0 0 3px;
+	}
+	input[type='email'] ~ .button {
+		border-radius: 0 3px 3px 0;
+		margin-top: 0;
+		margin-left: -6px;
+	}
+}
+
+.badge {
+	border: 1px solid white;
+	display: inline-block;
+	opacity: 0.5;
+	padding: 0.2rem 0.6rem;
+	border-radius: 3px;
+	font-size: 13px;
+}
+
+.button {
+	display: inline-block;
+	padding: 12px 24px;
+	background-color: white;
+	color: #151518;
+	border-radius: 3px;
+	font-size: inherit;
+	line-height: inherit;
+	transition: opacity 0.2s;
+	text-decoration: none;
+	-webkit-appearance: none;
+}
+
+.button:hover {
+	opacity: 0.9;
+}
+
+.button.inverted {
+	background-color: #0070d6;
+	color: white;
+}
+
+.invert {
+	color: #ffffff;
+}
+
+.invert h1,
+.invert h2,
+.invert h3,
+.invert h4 {
+	color: #ffffff;
+}
+
+.section {
+	text-align: center;
+	padding: 6rem 0 10rem;
+	background-color: white;
+}
+
+@media only screen and (max-width: 540px) {
+	.section {
+		padding: 3rem 0 3rem;
+	}
+}
+
+.section.blue {
+	background-image: linear-gradient(-134deg, #0070d6 0%, #2287e5 100%);
+	color: white;
+}
+
+.section .feature-tiles {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	justify-content: flex-start;
+	margin: 3rem -1rem;
+	padding: 0 1rem;
+	overflow: auto;
+	scroll-behavior: smooth;
+}
+
+.section .feature-tiles .feature {
+	margin: 0 1rem;
+}
+
+.section .feature-tiles .feature:last-child {
+	margin-right: 0;
+	padding-right: 1rem;
+}
+
+.section .feature-tiles .feature:first-child {
+	margin-left: 0;
+}
+
+.section .feature-tiles .feature .tile {
+	height: 220px;
+	width: 200px;
+	border-radius: 5px;
+	margin-bottom: 1rem;
+}
+
+.section .feature-tiles .feature .tile img {
+	object-fit: cover;
+	max-height: 100%;
+	max-width: 100%;
+}
+
+.dark {
+	background-color: #151518;
+	color: #ffffff;
+}
+
+.dark h1,
+.dark h2,
+.dark h3,
+.dark h4 {
+	color: #ffffff;
+}
+
+.hero {
+	padding-bottom: 0;
+	overflow: hidden;
+	padding-top: 3rem;
+}
+
+.hero .wrapper {
+	max-width: none;
+	width: 75%;
+}
+
+@media only screen and (max-width: 540px) {
+	.hero .wrapper {
+		width: 90%;
+	}
+}
+
+.hero .hero-links a {
+	margin-right: 12px;
+	text-decoration: none;
+	opacity: 0.5;
+	margin-left: 0;
+}
+
+.hero .hero-links a img {
+	margin-right: 6px;
+}
+
+.hero .hero-links a:hover {
+	opacity: 0.75;
+}
+
+.hero h1 {
+	font-weight: 200;
+	margin: 15vh 0 0 0;
+	padding-top: 0rem;
+}
+
+.hero h1 strong {
+	font-weight: 500;
+}
+
+.hero h1 u {
+	border-bottom: 5px solid currentColor;
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 959px) {
+	.hero h1 u {
+		border-width: 3px;
+	}
+}
+
+@media only screen and (max-width: 540px) {
+	.hero h1 u {
+		border-width: 2px;
+	}
+}
+
+.hero p {
+	font-size: 1.2rem;
+	max-width: 540px;
+	margin: 72px 0 24px;
+}
+
+.hero p.small-copy {
+	font-size: 0.8rem;
+	margin-top: 18px;
+	max-width: 400px;
+	opacity: 0.5;
+}
+
+.hero .button {
+	margin-top: 2rem;
+}
+
+.hero-github {
+	margin-left: 12px;
+}
+
+.hero-github img {
+	width: 25px;
+	height: 25px;
+	vertical-align: middle;
+}
+
+.application {
+	position: relative;
+	padding: 14rem 0 4rem;
+}
+
+@media only screen and (max-width: 540px) {
+	.application {
+		padding-top: 4rem;
+	}
+}
+
+.application img {
+	display: block;
+	width: 100%;
+	box-shadow: 0 5px 30px rgba(0, 0, 0, 0.15);
+	border-radius: 3px;
+	width: 90%;
+	max-width: 1440px;
+	margin: 0 auto;
+	position: relative;
+}
+
+.application::before {
+	content: '';
+	position: absolute;
+	display: block;
+	width: 100%;
+	height: 50%;
+	top: 0;
+	left: 0;
+	background-color: #151518;
+	margin-top: -1px;
+}
+
+.mail {
+	padding-top: 0;
+	padding-bottom: 8rem;
+}
+
+@media only screen and (max-width: 540px) {
+	.mail {
+		padding-bottom: 4rem;
+	}
+}
+
+.mail p {
+	max-width: 480px;
+	margin: 0 auto;
+	width: 90%;
+}
+
+.source-image {
+	max-width: 404px;
+	width: 90%;
+	margin: 30px auto;
+}
+
+.contribute .button {
+	background: #0070d6;
+	color: #fff;
+	margin-top: 42px;
+}
+
+.contribute .contribute-mail {
+	margin-top: 1rem;
+	display: inline-block;
+	font-size: 1rem;
+	text-decoration: none;
+}
+
+.contribute .contribute-mail:hover {
+	text-decoration: underline;
+}
+
+.features {
+	background-image: linear-gradient(134deg, #0070d6 0%, #2287e5 100%);
+	text-align: left;
+	overflow: hidden;
+}
+
+.features h2,
+.features p {
+	max-width: 540px;
+}
+
+.features-application {
+	position: relative;
+	margin: 8rem 0;
+	display: flex;
+	flex-direction: column;
+}
+
+@media only screen and (max-width: 540px) {
+	.features-application {
+		margin: 6rem 0;
+	}
+}
+
+.features-application-item {
+	max-width: 200px;
+	position: absolute;
+	top: 250px;
+}
+
+@media only screen and (max-width: 540px) {
+	.features-application-item {
+		max-width: 100%;
+		position: static;
+		margin: 2rem 0 0 0;
+	}
+}
+
+.features-application-item h4 {
+	position: relative;
+	display: inline-block;
+}
+
+.features-application-item h4:after {
+	content: '';
+	position: absolute;
+	left: 100%;
+	margin-left: 15px;
+	top: 15px;
+	width: calc(230px - 100%);
+	height: 1px;
+	background-color: white;
+}
+
+@media only screen and (max-width: 540px) {
+	.features-application-item h4:after {
+		display: none;
+	}
+}
+
+.features-application-item p {
+	font-size: 13px;
+	margin: 0.5rem 0;
+}
+
+.features-application-item:first-of-type {
+	top: 95px;
+}
+
+.features-application-item:last-of-type {
+	top: 400px;
+}
+
+.features-application-image {
+	width: 1080px;
+	margin-left: 260px;
+	box-shadow: 0 2px 20px rgba(0, 0, 0, 0.15);
+}
+
+@media only screen and (max-width: 540px) {
+	.features-application-image {
+		width: 550px;
+		margin-left: 0;
+		order: -1;
+	}
+}
+
+.features-additional {
+	max-width: 320px;
+}
+
+.features-additional h3 {
+	margin: 0.75rem 0 0.5rem;
+}
+
+.features-additional img {
+	width: 50px;
+}
+
+.features-additional:last-of-type {
+	text-align: right;
+	margin: -50px 0 0 auto;
+}
+
+@media only screen and (max-width: 540px) {
+	.features-additional:last-of-type {
+		margin: 4rem 0 0 0;
+		text-align: left;
+	}
+}
+
+.ssot-image {
+	width: 90%;
+	max-width: 636px;
+}
+
+.about {
+	background-color: #f4f6fa;
+}
+
+.about p {
+	max-width: 540px;
+	margin: 0 auto;
+}
+
+.about-people {
+	max-width: 520px;
+	margin: 0 auto;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+}
+
+@media only screen and (max-width: 540px) {
+	.about-people {
+		grid-template-columns: 1fr;
+	}
+}
+
+.about-people-item {
+	padding: 30px 20px;
+	border-radius: 5px;
+	background-color: white;
+	margin: 10px;
+	box-sizing: border-box;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+	text-decoration: none;
+	transition: box-shadow 0.2s;
+}
+
+.about-people-item:hover {
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.about-people-item h4 {
+	font-size: 1rem;
+}
+
+.about-people-item p {
+	font-size: 13px;
+}
+
+.about-people:after {
+	content: '';
+	display: block;
+	clear: both;
+}
+
+.social {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin: 42px 0;
+}
+
+.social a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 540px) {
+	.social {
+		flex-direction: column;
+	}
+}
+
+.social-item {
+	padding: 12px 12px;
+	margin: 0 18px;
+	border: 1px solid #0070d6;
+	border-radius: 5px;
+	color: #0070d6;
+}
+
+@media only screen and (max-width: 540px) {
+	.social-item {
+		margin: 8px 0;
+	}
+}
+
+.social-item::before {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	margin: 0 8px -2px 0;
+}
+
+.social-item.twitter::before {
+	content: '';
+	background: url(https://media.meetalva.io/social-twitter.svg) no-repeat;
+	background-position: center;
+	background-size: 16px 16px;
+}
+
+.social-item.facebook::before {
+	content: '';
+	background: url(https://media.meetalva.io/social-facebook.svg) no-repeat;
+	background-position: center;
+	background-size: 16px 16px;
+}
+
+.footer {
+	background-color: #151518;
+	padding-bottom: 6rem;
+	color: #fff;
+}
+
+.footer .legallink {
+	margin-right: 1rem;
+}
+
+.footer .legallink:last-child {
+	margin: 0;
+}
+
+.wrapper {
+	max-width: 720px;
+	padding: 0 1rem;
+	margin: auto;
+	width: 90%;
+}
+
+.wrapper.left {
+	text-align: left;
+}

--- a/website/website.js
+++ b/website/website.js
@@ -1,0 +1,32 @@
+function getOS() {
+	var OS = 'undefinedOS';
+	if (navigator.appVersion.indexOf('Win') != -1) OS = { name: 'Windows', file: '.exe' };
+	if (navigator.appVersion.indexOf('Mac') != -1) OS = { name: 'macOS', file: '.dmg' };
+
+	return OS;
+}
+
+function latestOSRelease(os) {
+	fetch('https://api.github.com/repos/meetalva/alva/releases/latest')
+		.then(response => response.json())
+		.then(data => {
+			for (let i of data.assets) {
+				if (i.name.indexOf(os.file) !== -1) {
+					generateDownloadLink(i.browser_download_url, os);
+					return;
+				}
+			}
+		});
+}
+
+function generateDownloadLink(url, os) {
+	var button = document.querySelector('.js-download-button');
+	var buttonText = button.innerHTML;
+	button.href = url;
+	button.innerHTML = buttonText + ' for ' + os.name;
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+	const os = getOS();
+	latestOSRelease(os);
+});


### PR DESCRIPTION
This PR demonstrates how we could use [patternplate cover](https://patternplate.github.io/doc/docs/guides/cover?guides-enabled=true) to create the meetalva.io website.

## Steps to test

* `yarn patternplate`
* Access http://localhost:1337 for the website
* Access http://localhost:1337/#be-part-of-the-future-of-design for a link leading to the underlying patternplate interface
* Access http://localhost:1337/?reload=true for auto-reloading capabilities