### PR TITLE
feat: add shortcut to switch pages

### DIFF
--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -395,6 +395,7 @@ export function createMenu(ctx: MenuContext): void {
 				{
 					label: 'Next Page',
 					accelerator: 'CmdOrCtrl+Alt+Right',
+					enabled: ctx.store.getLastPage() !== ctx.store.getCurrentPage(),
 					click: () => {
 						ctx.store.setNextPage();
 					}

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -385,6 +385,20 @@ export function createMenu(ctx: MenuContext): void {
 					type: 'separator'
 				},
 				{
+					label: 'Next Page',
+					accelerator: 'CmdOrCtrl+Alt+Left',
+					click: () => {
+						ctx.store.setPreviousPage();
+					}
+				},
+				{
+					label: 'Next Page',
+					accelerator: 'CmdOrCtrl+Alt+Right',
+					click: () => {
+						ctx.store.setNextPage();
+					}
+				},
+				{
 					label: '&Show Elements & Components',
 					type: 'checkbox',
 					checked: true,

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -387,6 +387,7 @@ export function createMenu(ctx: MenuContext): void {
 				{
 					label: 'Previous Page',
 					accelerator: 'CmdOrCtrl+Alt+Left',
+					enabled: ctx.store.getFirstPage() !== ctx.store.getCurrentPage(),
 					click: () => {
 						ctx.store.setPreviousPage();
 					}

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -389,10 +389,10 @@ export function createMenu(ctx: MenuContext): void {
 					accelerator: 'CmdOrCtrl+Alt+Left',
 					enabled: typeof ctx.store.getPreviousPage() !== 'undefined',
 					click: () => {
-						const nextPage = ctx.store.getPreviousPage();
+						const previousPage = ctx.store.getPreviousPage();
 
-						if (nextPage) {
-							ctx.store.setActivePage(nextPage);
+						if (previousPage) {
+							ctx.store.setActivePage(previousPage);
 						}
 					}
 				},

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -385,7 +385,7 @@ export function createMenu(ctx: MenuContext): void {
 					type: 'separator'
 				},
 				{
-					label: 'Next Page',
+					label: 'Previous Page',
 					accelerator: 'CmdOrCtrl+Alt+Left',
 					click: () => {
 						ctx.store.setPreviousPage();

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -387,17 +387,25 @@ export function createMenu(ctx: MenuContext): void {
 				{
 					label: 'Previous Page',
 					accelerator: 'CmdOrCtrl+Alt+Left',
-					enabled: ctx.store.getFirstPage() !== ctx.store.getCurrentPage(),
+					enabled: typeof ctx.store.getPreviousPage() !== 'undefined',
 					click: () => {
-						ctx.store.setPreviousPage();
+						const nextPage = ctx.store.getPreviousPage();
+
+						if (nextPage) {
+							ctx.store.setActivePage(nextPage);
+						}
 					}
 				},
 				{
 					label: 'Next Page',
 					accelerator: 'CmdOrCtrl+Alt+Right',
-					enabled: ctx.store.getLastPage() !== ctx.store.getCurrentPage(),
+					enabled: typeof ctx.store.getNextPage() !== 'undefined',
 					click: () => {
-						ctx.store.setNextPage();
+						const nextPage = ctx.store.getNextPage();
+
+						if (nextPage) {
+							ctx.store.setActivePage(nextPage);
+						}
 					}
 				},
 				{

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -606,6 +606,40 @@ export class ViewStore {
 		return this.project.getPages()[0];
 	}
 
+	@Mobx.action
+	public getPreviousPage(): Model.Page | undefined {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		return this.project.getPages()[index - 1];
+	}
+
+	@Mobx.action
+	public getNextPage(): Model.Page | undefined {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		return this.project.getPages()[index + 1];
+	}
+
 	public getFocusedItem(): Model.Element | Model.Page | undefined {
 		if (!this.project) {
 			return;

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -1205,4 +1205,9 @@ export class ViewStore {
 
 		this.setActivePageByIndex(index - 1);
 	}
+
+	@Mobx.action
+	public getFirstPage(): Model.Page {
+		return this.project.getPages()[0];
+	}
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -601,6 +601,11 @@ export class ViewStore {
 		return this.project.getElements().find(element => element.getHighlighted());
 	}
 
+	@Mobx.action
+	public getFirstPage(): Model.Page {
+		return this.project.getPages()[0];
+	}
+
 	public getFocusedItem(): Model.Element | Model.Page | undefined {
 		if (!this.project) {
 			return;
@@ -617,6 +622,11 @@ export class ViewStore {
 
 	public getFocusedItemType(): FocusedItemType {
 		return this.focusedItemType;
+	}
+
+	@Mobx.action
+	public getLastPage(): Model.Page {
+		return this.project.getPages()[this.project.getPages().length - 1];
 	}
 
 	public getMetaDown(): boolean {
@@ -1040,8 +1050,42 @@ export class ViewStore {
 	}
 
 	@Mobx.action
+	public setNextPage(): void {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		this.setActivePageByIndex(index + 1);
+	}
+
+	@Mobx.action
 	public setPatternSearchTerm(patternSearchTerm: string): void {
 		this.app.setSearchTerm(patternSearchTerm);
+	}
+
+	@Mobx.action
+	public setPreviousPage(): void {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		this.setActivePageByIndex(index - 1);
 	}
 
 	@Mobx.action
@@ -1170,49 +1214,5 @@ export class ViewStore {
 			id: uuid.v4(),
 			payload: project.toJSON()
 		});
-	}
-
-	@Mobx.action
-	public setNextPage(): void {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		this.setActivePageByIndex(index + 1);
-	}
-
-	@Mobx.action
-	public setPreviousPage(): void {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		this.setActivePageByIndex(index - 1);
-	}
-
-	@Mobx.action
-	public getFirstPage(): Model.Page {
-		return this.project.getPages()[0];
-	}
-
-	@Mobx.action
-	public getLastPage(): Model.Page {
-		return this.project.getPages()[this.project.getPages().length - 1];
 	}
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -1171,4 +1171,38 @@ export class ViewStore {
 			payload: project.toJSON()
 		});
 	}
+
+	@Mobx.action
+	public setNextPage(): void {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		this.setActivePageByIndex(index + 1);
+	}
+
+	@Mobx.action
+	public setPreviousPage(): void {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		this.setActivePageByIndex(index - 1);
+	}
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -1210,4 +1210,9 @@ export class ViewStore {
 	public getFirstPage(): Model.Page {
 		return this.project.getPages()[0];
 	}
+
+	@Mobx.action
+	public getLastPage(): Model.Page {
+		return this.project.getPages()[this.project.getPages().length - 1];
+	}
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -602,11 +602,6 @@ export class ViewStore {
 	}
 
 	@Mobx.action
-	public getFirstPage(): Model.Page {
-		return this.project.getPages()[0];
-	}
-
-	@Mobx.action
 	public getPreviousPage(): Model.Page | undefined {
 		const page = this.getCurrentPage();
 
@@ -656,11 +651,6 @@ export class ViewStore {
 
 	public getFocusedItemType(): FocusedItemType {
 		return this.focusedItemType;
-	}
-
-	@Mobx.action
-	public getLastPage(): Model.Page {
-		return this.project.getPages()[this.project.getPages().length - 1];
 	}
 
 	public getMetaDown(): boolean {
@@ -1084,42 +1074,8 @@ export class ViewStore {
 	}
 
 	@Mobx.action
-	public setNextPage(): void {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		this.setActivePageByIndex(index + 1);
-	}
-
-	@Mobx.action
 	public setPatternSearchTerm(patternSearchTerm: string): void {
 		this.app.setSearchTerm(patternSearchTerm);
-	}
-
-	@Mobx.action
-	public setPreviousPage(): void {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		this.setActivePageByIndex(index - 1);
 	}
 
 	@Mobx.action

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -601,40 +601,6 @@ export class ViewStore {
 		return this.project.getElements().find(element => element.getHighlighted());
 	}
 
-	@Mobx.action
-	public getPreviousPage(): Model.Page | undefined {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		return this.project.getPages()[index - 1];
-	}
-
-	@Mobx.action
-	public getNextPage(): Model.Page | undefined {
-		const page = this.getCurrentPage();
-
-		if (!page) {
-			return;
-		}
-
-		const index = this.project.getPageIndex(page);
-
-		if (typeof index !== 'number') {
-			return;
-		}
-
-		return this.project.getPages()[index + 1];
-	}
-
 	public getFocusedItem(): Model.Element | Model.Page | undefined {
 		if (!this.project) {
 			return;
@@ -659,6 +625,23 @@ export class ViewStore {
 
 	public getNameEditableElement(): Model.Element | undefined {
 		return this.project.getElements().find(e => e.getNameEditable());
+	}
+
+	@Mobx.action
+	public getNextPage(): Model.Page | undefined {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		return this.project.getPages()[index + 1];
 	}
 
 	public getPageById(id: string): Model.Page | undefined {
@@ -709,6 +692,23 @@ export class ViewStore {
 
 	public getPatternSearchTerm(): string {
 		return this.app.getSearchTerm();
+	}
+
+	@Mobx.action
+	public getPreviousPage(): Model.Page | undefined {
+		const page = this.getCurrentPage();
+
+		if (!page) {
+			return;
+		}
+
+		const index = this.project.getPageIndex(page);
+
+		if (typeof index !== 'number') {
+			return;
+		}
+
+		return this.project.getPages()[index - 1];
 	}
 
 	public getProject(): Model.Project {


### PR DESCRIPTION
For easier page switches I added two shortcuts.

## Content
* Add shortcuts for next and previous page

## Todo
- [x] Add shortcuts to menu
- [x] Only enable "next page" when there's a page
- [x] Only enable "previous page" when there's a page