### PR TITLE
WIP chore: remove project name

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -188,7 +188,6 @@ const userStore = new ElectronStore();
 
 				if (path) {
 					const project = Project.create({
-						name: 'Untitled Project',
 						path
 					});
 

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -14,7 +14,6 @@ export interface ProjectProperties {
 	id?: string;
 	lastChangedAuthor?: string;
 	lastChangedDate?: Date;
-	name: string;
 	pages: Page[];
 	path: string;
 	patternLibrary: PatternLibrary;
@@ -22,7 +21,6 @@ export interface ProjectProperties {
 }
 
 export interface ProjectCreateInit {
-	name: string;
 	path: string;
 }
 
@@ -52,8 +50,6 @@ export class Project {
 	 */
 	public constructor(init: ProjectProperties) {
 		this.patternLibrary = init.patternLibrary;
-		this.name = init.name;
-
 		this.id = init.id ? init.id : uuid.v4();
 		this.pages = init.pages ? init.pages : [];
 		this.path = init.path;
@@ -105,7 +101,6 @@ export class Project {
 		});
 
 		const project = new Project({
-			name: init.name,
 			pages: [],
 			path: init.path,
 			patternLibrary,
@@ -138,7 +133,6 @@ export class Project {
 
 		const project = new Project({
 			id: serialized.id,
-			name: serialized.name,
 			path: serialized.path,
 			pages: [],
 			patternLibrary,


### PR DESCRIPTION
Because we do not use the project name any more, I removed it from the code.

## Bugs
- [ ] HTML Export: Set new name as default file