### PR TITLE
WIP feat: recent documents menu

### DIFF
--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -106,6 +106,7 @@ export function createMenu(ctx: MenuContext): void {
 							return;
 						}
 						ctx.store.save();
+						app.addRecentDocument(project.getPath());
 					}
 				},
 				{

--- a/src/electron/create-menu.ts
+++ b/src/electron/create-menu.ts
@@ -71,6 +71,14 @@ export function createMenu(ctx: MenuContext): void {
 					}
 				},
 				{
+					role: 'recentdocuments',
+					submenu: [
+						{
+							role: 'clearrecentdocuments'
+						}
+					]
+				},
+				{
 					type: 'separator'
 				},
 				{
@@ -384,7 +392,7 @@ export function createMenu(ctx: MenuContext): void {
 				{
 					type: 'separator'
 				},
-        {
+				{
 					label: 'Previous Page',
 					accelerator: 'CmdOrCtrl+Alt+Left',
 					enabled: typeof ctx.store.getPreviousPage() !== 'undefined',

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -195,6 +195,8 @@ const userStore = new ElectronStore();
 
 					await Persistence.persist(path, project);
 
+					app.addRecentDocument(path);
+
 					send({
 						type: ServerMessageType.CreateNewFileResponse,
 						id: message.id,
@@ -235,6 +237,8 @@ const userStore = new ElectronStore();
 					if (typeof project === 'object') {
 						project.path = path;
 					}
+
+					app.addRecentDocument(path);
 
 					send({
 						type: ServerMessageType.OpenFileResponse,


### PR DESCRIPTION
This feature adds recently opened or newly created documents to the menu, with an option to clear recent files.

Adding documents uses `app.addRecentDocument(path)`:
https://electronjs.org/docs/api/app#appaddrecentdocumentpath-macos-windows

The recent document list is handled by macOS / Windows, not the electron app.
The list on macOS stores up to 10 items.

Adding the Recent Files Menu happens with:
```
const template = [
  {
    label: 'File',
    submenu: [
      {
        role: 'recentdocuments',
        submenu: [
          {
            role: 'clearrecentdocuments'
          }
        ]
      }
    ]
  }
]
```
read more: https://github.com/electron/electron/pull/11166

ToDo:
- [x] Add to list on save (CmdOrCtrl+S)
- [ ] There might be some bugs
- [ ] Test behaviour

Known Bugs:
- [ ] When opening a Document from the recent documents menu it doesn't take the first place in the list