### PR TITLE
fix: allow sidebars to scroll

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -90,7 +90,7 @@ const StyledMainArea = styled(StyledLayout)`
 const StyledSideBar = styled(StyledLayout)`
 	flex-basis: 240px;
 	height: 100%;
-	overflow-y: hidden;
+	overflow-y: auto;
 `;
 
 export interface FixedAreaProps {


### PR DESCRIPTION
If a sidebar has too much content for the viewport, you can scroll down now.

Fixes #572