### PR TITLE
fix: disable doubleClick for chrome elements

### DIFF
--- a/src/components/bug-report/index.tsx
+++ b/src/components/bug-report/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 export interface BugReportProps {
 	onClick?: React.MouseEventHandler<HTMLElement>;
+	onDoubleClick?: React.MouseEventHandler<HTMLElement>;
 	title: string;
 }
 
@@ -14,7 +15,12 @@ const StyledBugReport = styled.div`
 
 export const BugReport: React.StatelessComponent<BugReportProps> = props => (
 	<StyledBugReport>
-		<Button order={ButtonOrder.Secondary} size={ButtonSize.Small} onClick={props.onClick}>
+		<Button
+			order={ButtonOrder.Secondary}
+			size={ButtonSize.Small}
+			onClick={props.onClick}
+			onDoubleClick={props.onDoubleClick}
+		>
 			{props.title}
 		</Button>
 	</StyledBugReport>

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
 	/** @description For dark backgrounds */
 	inverted?: boolean;
 	onClick?: React.MouseEventHandler<HTMLElement>;
+	onDoubleClick?: React.MouseEventHandler<HTMLElement>;
 	/** @description Visual weight @default Primary */
 	order?: ButtonOrder;
 	/** @description Spatial weight @default */
@@ -106,6 +107,7 @@ const StyledButton = styled.button`
 export const Button: React.StatelessComponent<ButtonProps> = props => (
 	<StyledButton
 		onClick={props.onClick}
+		onDoubleClick={props.onDoubleClick}
 		textColor={props.textColor}
 		order={props.order}
 		size={props.size}

--- a/src/components/layout-switch/layout-switch.tsx
+++ b/src/components/layout-switch/layout-switch.tsx
@@ -9,6 +9,7 @@ export interface LayoutSwitchProps {
 	active?: boolean;
 	onPrimaryClick?: React.MouseEventHandler<HTMLElement>;
 	onSecondaryClick?: React.MouseEventHandler<HTMLElement>;
+	onDoubleClick?: React.MouseEventHandler<HTMLElement>;
 	children?: React.ReactNode;
 }
 
@@ -60,7 +61,7 @@ const StyledSecondaryContainer = styled.label`
 `;
 
 export const LayoutSwitch: React.SFC<LayoutSwitchProps> = props => (
-	<StyledLayoutSwitch>
+	<StyledLayoutSwitch onDoubleClick={props.onDoubleClick}>
 		<StyledPrimaryContainer onClick={props.onPrimaryClick} active={props.active}>
 			<Layout size={IconSize.XS} strokeWidth={1.5} />
 		</StyledPrimaryContainer>

--- a/src/components/view-switch/index.tsx
+++ b/src/components/view-switch/index.tsx
@@ -154,6 +154,9 @@ export const ViewSwitch: React.SFC<ViewSwitchProps> = (props): JSX.Element => (
 		<StyledLeftIcon
 			color={Color.Grey60}
 			onClick={props.onLeftClick}
+			onDoubleClick={event => {
+				event.stopPropagation();
+			}}
 			size={IconSize.XS}
 			visible={props.leftVisible}
 		/>
@@ -161,6 +164,9 @@ export const ViewSwitch: React.SFC<ViewSwitchProps> = (props): JSX.Element => (
 		<StyledRightIcon
 			color={Color.Grey60}
 			onClick={props.onRightClick}
+			onDoubleClick={event => {
+				event.stopPropagation();
+			}}
 			size={IconSize.XS}
 			visible={props.rightVisible}
 		/>

--- a/src/container/chrome/chrome-container.tsx
+++ b/src/container/chrome/chrome-container.tsx
@@ -86,6 +86,9 @@ export const ChromeContainer = MobxReact.inject('store')(
 							payload: 'https://github.com/meetalva/alva/labels/type%3A%20bug'
 						});
 					}}
+					onDoubleClick={event => {
+						event.stopPropagation();
+					}}
 				/>
 				{props.children}
 			</Chrome>

--- a/src/container/chrome/chrome-switch.tsx
+++ b/src/container/chrome/chrome-switch.tsx
@@ -27,6 +27,9 @@ export class ChromeSwitch extends React.Component {
 					onSecondaryClick={() => {
 						layoutMenu(store);
 					}}
+					onDoubleClick={event => {
+						event.stopPropagation();
+					}}
 				/>
 			</div>
 		);


### PR DESCRIPTION
I have added `doubleClick` event along with `event.stopPropagation` to elements in `<Chrome />` not to trigger `<Chrome />`'s `doubleClick` event. This pull request should resolve issue #571. 