### PR TITLE
fix: keep builtin library ids stable

### DIFF
--- a/src/model/pattern-library/pattern-library.ts
+++ b/src/model/pattern-library/pattern-library.ts
@@ -39,11 +39,11 @@ export interface PatternLibraryCreateOptions {
 
 export class PatternLibrary {
 	public readonly model = Types.ModelName.PatternLibrary;
+	private readonly id: string;
 
 	@Mobx.observable private bundleId: string;
 	@Mobx.observable private bundle: string;
 	@Mobx.observable private description: string;
-	@Mobx.observable private id: string;
 	@Mobx.observable private name: string;
 	@Mobx.observable private patternProperties: Map<string, AnyPatternProperty> = new Map();
 	@Mobx.observable private patterns: Map<string, Pattern> = new Map();
@@ -389,7 +389,6 @@ export class PatternLibrary {
 		this.bundleId = b.bundleId;
 		this.bundle = b.bundle;
 		this.description = b.description;
-		this.id = b.id;
 		this.name = b.name;
 		this.origin = b.origin;
 		this.state = this.state;

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -286,22 +286,19 @@ export class Project {
 	}
 
 	@Mobx.action
-	public addPatternLibrary(patternLibrary: PatternLibrary): void {
-		if (patternLibrary.getOrigin() === Types.PatternLibraryOrigin.BuiltIn) {
+	public addPatternLibrary(lib: PatternLibrary): void {
+		if (lib.getOrigin() === Types.PatternLibraryOrigin.BuiltIn) {
 			const updatedLibrary = Project.createBuiltinPatternLibrary({
-				getGlobalEnumOptionId: (enumId, contextId) =>
-					patternLibrary.assignEnumOptionId(enumId, contextId),
-				getGlobalPatternId: contextId => patternLibrary.assignPatternId(contextId),
-				getGlobalPropertyId: (patternId, contextId) =>
-					patternLibrary.assignPropertyId(patternId, contextId),
-				getGlobalSlotId: (patternId, contextId) =>
-					patternLibrary.assignSlotId(patternId, contextId)
+				getGlobalEnumOptionId: lib.assignEnumOptionId.bind(lib),
+				getGlobalPatternId: lib.assignPatternId.bind(lib),
+				getGlobalPropertyId: lib.assignPropertyId.bind(lib),
+				getGlobalSlotId: lib.assignSlotId.bind(lib)
 			});
 
-			patternLibrary.update(updatedLibrary);
+			lib.update(updatedLibrary);
 		}
 
-		this.patternLibraries.set(patternLibrary.getId(), patternLibrary);
+		this.patternLibraries.set(lib.getId(), lib);
 	}
 
 	@Mobx.action


### PR DESCRIPTION
This fixes an issue where the builtin pattern library was duplicated in certain conditions. 

This was caused by `Project.addPatternLibrary` incorrectly changing the id of updated builtin pattern library instances and adding new entries to the `.libraries` map.

After this change the builting pattern library is kepts stable, so no new entries are added to the relevant data structure.