### PR TITLE
fix: ensure component registry is in sync

### DIFF
--- a/src/server/create-preview-route.ts
+++ b/src/server/create-preview-route.ts
@@ -1,6 +1,7 @@
 import * as Express from 'express';
 import * as PreviewDocument from '../preview-document';
 import { Sender } from '../sender/server';
+import * as Types from '../types';
 import * as Model from '../model';
 
 export interface PreviewRouteOptions {
@@ -19,18 +20,17 @@ export function createPreviewRoute(options: PreviewRouteOptions): Express.Reques
 			return;
 		}
 
-		const clone = Model.Project.from(project.toJSON());
-		clone.getPatternLibraries().map(l => l.setBundle(''));
+		const userLibraries = project
+			.getPatternLibraries()
+			.filter(lib => lib.getOrigin() === Types.PatternLibraryOrigin.UserProvided);
+
+		const script = lib =>
+			`<script src="/libraries/${lib.getId()}.js" data-bundle="${lib.getBundleId()}"></script>`;
 
 		res.send(
 			PreviewDocument.previewDocument({
-				data: clone.toJSON(),
-				scripts: project
-					.getPatternLibraries()
-					.map(
-						lib =>
-							`<script src="/libraries/${lib.getId()}.js" data-bundle="${lib.getBundleId()}"></script>`
-					)
+				data: project.toJSON(),
+				scripts: userLibraries.map(script)
 			})
 		);
 	};


### PR DESCRIPTION
Address a bug that caused the preview to fail rendering
of user-provided components directly after adding them
to a project.

This also derives the bundle script tags directly from the preview
instance of Project instead of applying script changes imperatively
for `MessageType.ChangePatternLibraries`.