### PR TITLE
fix: add element contents for unoccupied pattern slots

### DIFF
--- a/src/model/element/element-content.ts
+++ b/src/model/element/element-content.ts
@@ -80,6 +80,20 @@ export class ElementContent {
 		);
 	}
 
+	public static fromSlot(slot: PatternSlot, context: ElementContentContext): ElementContent {
+		return new ElementContent(
+			{
+				elementIds: [],
+				forcedOpen: false,
+				highlighted: false,
+				id: uuid.v4(),
+				open: false,
+				slotId: slot.getId()
+			},
+			context
+		);
+	}
+
 	public accepts(child: Element): boolean {
 		const parentElementId = this.getParentElementId();
 

--- a/src/model/element/element.ts
+++ b/src/model/element/element.ts
@@ -231,6 +231,11 @@ export class Element {
 	}
 
 	@Mobx.action
+	public addContent(content: ElementContent): void {
+		this.contentIds.push(content.getId());
+	}
+
+	@Mobx.action
 	public clone(opts?: { withState: boolean }): Element {
 		const withState = Boolean(opts && opts.withState);
 
@@ -259,7 +264,7 @@ export class Element {
 				return clones;
 			}, new Map());
 
-		const clonedContents = this.contentIds
+		const clonedContents = [...this.contentIds]
 			.map(contentId => this.project.getElementContentById(contentId))
 			.filter((content): content is ElementContent => typeof content !== 'undefined')
 			.map(content => content.clone({ withState }));
@@ -415,7 +420,7 @@ export class Element {
 	}
 
 	public getContents(): ElementContent[] {
-		return this.contentIds
+		return [...this.contentIds]
 			.map(contentId => this.project.getElementContentById(contentId))
 			.filter(
 				(elementContent): elementContent is ElementContent =>

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -818,11 +818,11 @@ export class Project {
 			const removed = message.payload.change.removed;
 			const member = mayBeMember as unknown[];
 
-			if (removed.length > 0) {
+			if (Array.isArray(member) && removed.length > 0) {
 				member.splice(message.payload.change.index, removed.length);
 			}
 
-			if (added.length > 0) {
+			if (Array.isArray(member) && added.length > 0) {
 				member.splice(message.payload.change.index, 0, ...added);
 			}
 		});

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -175,20 +175,9 @@ export class ViewStore {
 	public createElement(init: { dragged?: boolean; pattern: Model.Pattern }): Model.Element {
 		const project = this.getProject();
 
-		const elementContents = init.pattern.getSlots().map(
-			slot =>
-				new Model.ElementContent(
-					{
-						elementIds: [],
-						forcedOpen: false,
-						highlighted: false,
-						id: uuid.v4(),
-						open: false,
-						slotId: slot.getId()
-					},
-					{ project }
-				)
-		);
+		const elementContents = init.pattern
+			.getSlots()
+			.map(slot => Model.ElementContent.fromSlot(slot, { project }));
 
 		const element = new Model.Element(
 			{


### PR DESCRIPTION
Adresses a bug where adding a pattern slot to a pattern with
callsites would not update the appropriate elements inside Alva.

Steps to reproduce

1. Create new file
2. Connect DesignKit
3. Add element with Button pattern
4. Remove children prop from Button interface
5. Update the library inside Alva
6. Readd children prop to Button interface
7. Update the library inside Alva again
7a) Before fix: The button still does not accept children
7b) After fix: The button accepts children again
