### PR TITLE
fix: remove element border overlay

### DIFF
--- a/src/components/element/element.tsx
+++ b/src/components/element/element.tsx
@@ -89,7 +89,7 @@ const LABEL_BACKGROUND = (props: StyledElementLabelProps): string => {
 		case ElementState.Highlighted:
 			return Color.Grey90;
 		default:
-			return Color.Grey97;
+			return 'transparent';
 	}
 };
 


### PR DESCRIPTION
Have a look at the right element pane border (is missing for the text element)

Before:
<img width="310" alt="before" src="https://user-images.githubusercontent.com/8946766/45655009-608a9100-bade-11e8-8e88-8a2ec4398011.png">

After:
<img width="344" alt="after" src="https://user-images.githubusercontent.com/8946766/45655013-641e1800-bade-11e8-83c4-f1eca04d96de.png">
