### PR TITLE
fix: rename project settings to libraries

### DIFF
--- a/src/container/properties-switch.tsx
+++ b/src/container/properties-switch.tsx
@@ -25,8 +25,8 @@ export class PropertiesSwitch extends React.Component {
 					onClick={() => app.setRightSidebarTab(Types.RightSidebarTab.Properties)}
 				/>
 				<Components.TabSwitch
-					label="Project Settings"
-					title="Show Project Settings"
+					label="Libraries"
+					title="Show Libraries"
 					type={Components.TabSwitchType.Tab}
 					active={
 						app.getRightSidebarTab() === Types.RightSidebarTab.ProjectSettings


### PR DESCRIPTION
... so it’s more clear to users whats’s behind that tab.