### PR TITLE
feat: add `window.screenshot` for svg-convertible chrome screenshots

### DIFF
--- a/src/message/message.ts
+++ b/src/message/message.ts
@@ -75,7 +75,8 @@ export enum MessageType {
 	ChangeUserStore = 'user-store-change',
 	SelectElement = 'select-element',
 	HighlightElement = 'highlight-element',
-	WindowClose = 'window-close'
+	WindowClose = 'window-close',
+	ChromeScreenShot = 'chrome-screenshot',
 }
 
 export type Message =
@@ -151,7 +152,8 @@ export type Message =
 	| ChangeUserStore
 	| SelectElement
 	| HighlightElement
-	| WindowClose;
+	| WindowClose
+	| ChromeScreenShot;
 
 export type ActivatePage = Envelope<MessageType.ActivatePage, { id: string }>;
 export type AppLoaded = EmptyEnvelope<MessageType.AppLoaded>;
@@ -422,3 +424,10 @@ export type MobxAddMessage = Envelope<MessageType.MobxAdd, MobxAddPayload>;
 export type MobxDeleteMessage = Envelope<MessageType.MobxDelete, MobxDeletePayload>;
 export type MobxSpliceMessage = Envelope<MessageType.MobxSplice, MobxSplicePayload>;
 export type WindowClose = EmptyEnvelope<MessageType.WindowClose>;
+export type ChromeScreenShot = Envelope<
+	MessageType.ChromeScreenShot,
+	{
+		width: number;
+		height: number;
+	}
+>;

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -34,6 +34,19 @@ export function startRenderer(): void {
 
 	// tslint:disable-next-line:no-any
 	(window as any).store = store;
+
+	// tslint:disable-next-line:no-any
+	(window as any).screenshot = () => {
+		sender.send({
+			id: uuid.v4(),
+			type: MessageType.ChromeScreenShot,
+			payload: {
+				width: window.innerWidth,
+				height: window.innerHeight
+			}
+		});
+	};
+
 	console.log('Access ViewStore at .store');
 
 	createListeners({ store });


### PR DESCRIPTION
This adds a feature where a dev can create pdf screenshots of the Alva chrome via `window.screenshot`. 

This is useful for further conversions to SVG via `pdf2svg` as well as for bug reporting. Might be a good idea to power issue reporting with this later on? 