### PR TITLE
fix: open files via double-click & cli args

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -22,6 +22,11 @@ const CONTEXT: AppContext = Mobx.observable({
 });
 
 async function main(): Promise<void> {
+	if (process.argv.length > 1) {
+		const fileToOpenArg = process.argv[1];
+		CONTEXT.fileToOpen = fileToOpenArg;
+	}
+
 	const args = yargsParser(process.argv.slice(2));
 	CONTEXT.hot = args.hot || false;
 	CONTEXT.base = args.base || '';

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -17,7 +17,8 @@ const CONTEXT: AppContext = Mobx.observable({
 	sender: undefined,
 	win: undefined,
 	hot: undefined,
-	middlewares: []
+	middlewares: [],
+	fileToOpen: undefined
 });
 
 async function main(): Promise<void> {
@@ -66,6 +67,16 @@ async function main(): Promise<void> {
 		await main();
 	});
 }
+
+Electron.app.on('open-file', async (event, path) => {
+	event.preventDefault();
+
+	if (!path) {
+		return;
+	}
+
+	CONTEXT.fileToOpen = path;
+});
 
 Electron.app.on('ready', main);
 

--- a/src/electron/start-app.ts
+++ b/src/electron/start-app.ts
@@ -8,6 +8,7 @@ import * as getPort from 'get-port';
 import * as Message from '../message';
 import * as Mobx from 'mobx';
 import * as Model from '../model';
+import * as Fs from 'fs';
 import { Sender } from '../sender/server';
 import { showMainMenu } from './show-main-menu';
 import { createServer } from '../server';
@@ -71,6 +72,11 @@ export async function startApp(ctx: AppContext): Promise<{ emitter: Events.Event
 		() => ctx.fileToOpen,
 		() => {
 			if (!ctx.fileToOpen) {
+				return;
+			}
+
+			// TODO: Move check to persistence.read and return appropriate error message.
+			if (!Fs.existsSync(ctx.fileToOpen)) {
 				return;
 			}
 


### PR DESCRIPTION
## Proposed Changes
Short description of the changes:
* changed the way how file open requests coming from the os layer are handled

### Dev Notes
* this is a hotfix for the distributed executables
* ignore error message 'use strict' popping up when opening alva from the dev setup. we need to refactor cli arg handling down the road to get rid of this error as it is caused by assuming that the first cli arg represents the file to open. this is only true in some cases.

### Linked Issues
Fixes #[Issue]
