### PR TITLE
docs: update broken important resources in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ See the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md) for more info
 
 * bugs / feature requests: https://github.com/meetalva/alva/issues
 * website: https://meetalva.io
-* sprint board: https://github.com/meetalva/alva/projects/2
-* backlog board: https://github.com/meetalva/alva/projects/3
+* sprint board: https://github.com/meetalva/alva/projects/6
+* roadmap: https://github.com/meetalva/alva/projects/7
 
 ## Setup for contributors
 


### PR DESCRIPTION
## Proposed Changes
As reported in #631, I have updated the broken links with the possible most accurate ones. I have acted as "beta" board is the current sprint and roadmap is the backlog. But for the roadmap, I have updated the wording as well.

### Checklist
- [x] Added documentation of the changes

### Linked Issues
Fixes #631
