### PR TITLE
fix: honor back/next state on page drops correctly

### DIFF
--- a/src/model/page/page.ts
+++ b/src/model/page/page.ts
@@ -41,8 +41,6 @@ export class Page {
 	@Mobx.observable private name: string = 'Page';
 	@Mobx.observable public nameState: Types.EditableTitleState = Types.EditableTitleState.Editable;
 
-	// @Mobx.observable public isdroppable: boolean = false;
-
 	/**
 	 * UI property flags to highlight the area
 	 * where the page can be dropped.
@@ -228,6 +226,10 @@ export class Page {
 		return this.id;
 	}
 
+	public getIndex(): number {
+		return this.project.getPages().indexOf(this);
+	}
+
 	public getName(options?: { unedited: boolean }): string {
 		if ((!options || !options.unedited) && this.nameState === Types.EditableTitleState.Editing) {
 			return this.editedName;
@@ -258,22 +260,14 @@ export class Page {
 		this.active = active;
 	}
 
-	/**
-	 * Sets the value of the current state for
-	 * the back page droppable area.
-	 */
 	@Mobx.action
-	public setDroppableBackState(isdroppable: boolean): void {
-		this.droppablePageIndex.back = isdroppable;
+	public setDroppableBackState(droppable: boolean): void {
+		this.droppablePageIndex.back = droppable;
 	}
 
-	/**
-	 * Sets the value of the current state for
-	 * the next page droppable area.
-	 */
 	@Mobx.action
-	public setDroppableNextState(isdroppable: boolean): void {
-		this.droppablePageIndex.next = isdroppable;
+	public setDroppableNextState(droppable: boolean): void {
+		this.droppablePageIndex.next = droppable;
 	}
 
 	@Mobx.action

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -383,7 +383,7 @@ export class Project {
 			return;
 		}
 
-		const nextIndex = this.getPageIndex(page) + 1;
+		const nextIndex = page.getIndex() + 1;
 
 		if (typeof nextIndex !== 'number' || Number.isNaN(nextIndex)) {
 			return;
@@ -452,10 +452,6 @@ export class Project {
 		return this.pages.find(page => page.getId() === id);
 	}
 
-	public getPageIndex(page: Page): number {
-		return this.pages.indexOf(page);
-	}
-
 	public getPages(): Page[] {
 		return this.pages;
 	}
@@ -503,7 +499,7 @@ export class Project {
 			return;
 		}
 
-		const previousIndex = this.getPageIndex(page) - 1;
+		const previousIndex = page.getIndex() - 1;
 
 		if (typeof previousIndex !== 'number' || Number.isNaN(previousIndex)) {
 			return;
@@ -564,20 +560,28 @@ export class Project {
 
 	@Mobx.action
 	public movePageAfter(opts: { page: Page; targetPage: Page }): void {
-		const targetAvailable = this.pages.some(p => p.getId() === opts.targetPage.getId());
+		this.movePage({ ...opts, offset: 1 });
+	}
 
-		if (!targetAvailable) {
+	@Mobx.action
+	public movePageBefore(opts: { page: Page; targetPage: Page }): void {
+		this.movePage({ ...opts, offset: 0 });
+	}
+
+	@Mobx.action
+	public movePage(opts: { page: Page; targetPage: Page; offset: number }): void {
+		const targetAvailable = this.pages.some(p => p.getId() === opts.targetPage.getId());
+		const pageAvailable = this.pages.some(p => p.getId() === opts.page.getId());
+
+		if (!targetAvailable || !pageAvailable) {
 			return;
 		}
 
 		const index = this.pages.findIndex(p => opts.page.getId() === p.getId());
-
-		if (index > -1) {
-			this.pages.splice(index, 1);
-		}
+		this.pageList.splice(index, 1);
 
 		const targetIndex = this.pages.findIndex(p => opts.targetPage.getId() === p.getId());
-		this.pages.splice(targetIndex + 1, 0, opts.page);
+		this.pageList.splice(targetIndex + opts.offset, 0, opts.page.getId());
 	}
 
 	@Mobx.action
@@ -675,8 +679,7 @@ export class Project {
 			return false;
 		}
 
-		const pageIndex = this.getPageIndex(page);
-		this.pageList.splice(pageIndex, 1);
+		this.pageList.splice(page.getIndex(), 1);
 
 		this.pageList.splice(position, 0, page.getId());
 		return true;

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -695,7 +695,7 @@ export class ViewStore {
 
 	@Mobx.action
 	public removePage(page: Model.Page): void {
-		const index = this.project.getPageIndex(page);
+		const index = page.getIndex();
 
 		if (this.project.getPages().length > 1) {
 			if (index !== 0) {


### PR DESCRIPTION
This fixes a number of bugs around page drag/drop.

## Main change

1. Decided based on `DropState.next` vs `DropState.back` if the Page should be inserted after (`movePageAfter`) or before (`movePageBefore`). 
Implementing the case handling exposed another bug where dropping/dragging a page on itself was not handled. I changed it to not show the drop indicators in this case.

## Yak shaving

2. Remove `project.reArrangePagesIndex`, use `project.movePageTo` instead
3. Abstract `project.movePageAfter` to `project.movePageTo` to power `project.movePageAfter` and `project.movePageBefore`
4. Provide and use `getIndex` on `Page` to avoid intermediary states in `PageListContainer`. Only state in `PageListContainer` now is `draggedPage`.
