### PR TITLE
feat: parse jsdoc annotations on exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ There is no such thing as out-dated and static PNG screens, as the current versi
 ## Pattern Meta Data
 
 ### Pattern
+* **name**: TSDoc `@name [name]` - Used as the pattern name
+* **description**: TSDoc `@description [description]` - Used as subline for the pattern
+* **ignore**: TSDoc `@ignore` - Do not show this pattern
 
 ### Pattern Property
 

--- a/src/analyzer/typescript-react-analyzer/typescript-react-analyzer.ts
+++ b/src/analyzer/typescript-react-analyzer/typescript-react-analyzer.ts
@@ -163,6 +163,10 @@ function analyzePatternExport(
 	const contextId = `${ctx.candidate.id}:${exportName}`;
 	const id = ctx.options.getGlobalPatternId(contextId);
 
+	if (ex.ignore) {
+		return;
+	}
+
 	const properties = PropertyAnalyzer.analyze(propTypes.type, {
 		program: ctx.program,
 		getPropertyId(propertyContextId: string): string {
@@ -184,7 +188,7 @@ function analyzePatternExport(
 		pattern: {
 			model: Types.ModelName.Pattern,
 			contextId,
-			description: ctx.candidate.description,
+			description: ex.description ? ex.description : ctx.candidate.description,
 			exportName,
 			id,
 			name: exportName !== 'default' ? exportName : ctx.candidate.displayName,

--- a/src/analyzer/typescript-utils/get-export-infos.ts
+++ b/src/analyzer/typescript-utils/get-export-infos.ts
@@ -20,15 +20,28 @@ export function getExportInfos(
 				continue;
 			}
 
-			const exportName = isDefault ? undefined : declaration.name.getText();
-
 			const type = typechecker.getTypeAtLocation(declaration);
 			const exportType = new TypeScriptType(type, typechecker);
+
+			const jsDocTags = TypeScript.getJSDocTags(statement);
+			const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
+
+			const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
+			const exportDescription = descriptionTag ? descriptionTag.comment : '';
+
+			const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
+			const exportName = nameTag
+				? nameTag.comment
+				: isDefault
+					? undefined
+					: declaration.name.getText();
 
 			return [
 				{
 					name: exportName,
+					description: exportDescription || '',
 					type: exportType,
+					ignore: exportIgnore,
 					statement
 				}
 			];
@@ -48,7 +61,9 @@ export function getExportInfos(
 		return [
 			{
 				name: exportName,
+				description: '',
 				type: exportType,
+				ignore: false,
 				statement
 			}
 		];
@@ -64,7 +79,9 @@ export function getExportInfos(
 
 			return [
 				{
+					description: '',
 					type: exportType,
+					ignore: false,
 					statement
 				}
 			];
@@ -84,7 +101,9 @@ export function getExportInfos(
 
 			return {
 				name: exportName,
+				description: '',
 				type: exportType,
+				ignore: false,
 				statement
 			};
 		});

--- a/src/analyzer/typescript-utils/get-export-infos.ts
+++ b/src/analyzer/typescript-utils/get-export-infos.ts
@@ -53,17 +53,24 @@ export function getExportInfos(
 			return [];
 		}
 
-		const exportName = isDefault ? undefined : statement.name.text;
-
 		const type = typechecker.getTypeAtLocation(statement);
 		const exportType = new TypeScriptType(type, typechecker);
+
+		const jsDocTags = TypeScript.getJSDocTags(statement);
+		const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
+
+		const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
+		const exportDescription = descriptionTag ? descriptionTag.comment : '';
+
+		const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
+		const exportName = nameTag ? nameTag.comment : isDefault ? undefined : statement.name.text;
 
 		return [
 			{
 				name: exportName,
-				description: '',
+				description: exportDescription || '',
 				type: exportType,
-				ignore: false,
+				ignore: exportIgnore,
 				statement
 			}
 		];

--- a/src/analyzer/typescript-utils/get-export-infos.ts
+++ b/src/analyzer/typescript-utils/get-export-infos.ts
@@ -84,11 +84,21 @@ export function getExportInfos(
 			const type = typechecker.getTypeAtLocation(declaration);
 			const exportType = new TypeScriptType(type, typechecker);
 
+			const jsDocTags = TypeScript.getJSDocTags(statement);
+			const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
+
+			const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
+			const exportDescription = descriptionTag ? descriptionTag.comment : '';
+
+			const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
+			const exportName = nameTag ? nameTag.comment : undefined;
+
 			return [
 				{
-					description: '',
+					name: exportName,
+					description: exportDescription || '',
 					type: exportType,
-					ignore: false,
+					ignore: exportIgnore,
 					statement
 				}
 			];

--- a/src/analyzer/typescript-utils/get-export-infos.ts
+++ b/src/analyzer/typescript-utils/get-export-infos.ts
@@ -14,6 +14,12 @@ export function getExportInfos(
 		modifiers &&
 		modifiers.some(modifier => modifier.kind === TypeScript.SyntaxKind.DefaultKeyword);
 
+	const jsDocTags = TypeScript.getJSDocTags(statement);
+	const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
+
+	const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
+	const exportDescription = descriptionTag ? descriptionTag.comment : '';
+
 	if (TypeScript.isVariableStatement(statement)) {
 		for (const declaration of statement.declarationList.declarations) {
 			if (!declaration.type) {
@@ -22,12 +28,6 @@ export function getExportInfos(
 
 			const type = typechecker.getTypeAtLocation(declaration);
 			const exportType = new TypeScriptType(type, typechecker);
-
-			const jsDocTags = TypeScript.getJSDocTags(statement);
-			const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
-
-			const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
-			const exportDescription = descriptionTag ? descriptionTag.comment : '';
 
 			const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
 			const exportName = nameTag
@@ -56,12 +56,6 @@ export function getExportInfos(
 		const type = typechecker.getTypeAtLocation(statement);
 		const exportType = new TypeScriptType(type, typechecker);
 
-		const jsDocTags = TypeScript.getJSDocTags(statement);
-		const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
-
-		const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
-		const exportDescription = descriptionTag ? descriptionTag.comment : '';
-
 		const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
 		const exportName = nameTag ? nameTag.comment : isDefault ? undefined : statement.name.text;
 
@@ -84,12 +78,6 @@ export function getExportInfos(
 			const type = typechecker.getTypeAtLocation(declaration);
 			const exportType = new TypeScriptType(type, typechecker);
 
-			const jsDocTags = TypeScript.getJSDocTags(statement);
-			const exportIgnore = jsDocTags.some(tag => tag.tagName.escapedText === 'ignore');
-
-			const descriptionTag = jsDocTags.find(tag => tag.tagName.escapedText === 'description');
-			const exportDescription = descriptionTag ? descriptionTag.comment : '';
-
 			const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
 			const exportName = nameTag ? nameTag.comment : undefined;
 
@@ -111,16 +99,21 @@ export function getExportInfos(
 		}
 
 		return statement.exportClause.elements.map(exportSpecifier => {
-			const exportName = isDefault ? undefined : exportSpecifier.name.getText();
-
 			const type = typechecker.getTypeAtLocation(exportSpecifier);
 			const exportType = new TypeScriptType(type, typechecker);
 
+			const nameTag = jsDocTags.find(tag => tag.tagName.escapedText === 'name');
+			const exportName = nameTag
+				? nameTag.comment
+				: isDefault
+					? undefined
+					: exportSpecifier.name.getText();
+
 			return {
 				name: exportName,
-				description: '',
+				description: exportDescription || '',
 				type: exportType,
-				ignore: false,
+				ignore: exportIgnore,
 				statement
 			};
 		});

--- a/src/analyzer/typescript-utils/typescript-export.ts
+++ b/src/analyzer/typescript-utils/typescript-export.ts
@@ -13,6 +13,11 @@ export interface TypescriptExport {
 	name?: string;
 
 	/**
+	 * The description of the export
+	 */
+	description: string;
+
+	/**
 	 * The TypeScript export statement.
 	 */
 	statement: ts.Statement;
@@ -21,4 +26,9 @@ export interface TypescriptExport {
 	 * The type of the object exported.
 	 */
 	type: TypeScriptType;
+
+	/**
+	 * If the export should be ignored
+	 */
+	ignore: boolean;
 }


### PR DESCRIPTION
## Proposed Changes
Now you can add annotations to all kinds of exports in your library to set a name, description and optionally ignore the component.

Example:
```
/**
 * @name NewName
 * @description Hello Hello
 * @ignore
 */
export const Test: React.SFC = props => {
  return (
    <div>
      Test
    </div>
  );
};
```
