### PR TITLE
fix: retain pageList during serde cycle #644

### DIFF
--- a/src/model/project.test.ts
+++ b/src/model/project.test.ts
@@ -1,0 +1,35 @@
+import { Project } from './project';
+import { Page } from './page';
+
+test("project.update should apply b's page order to a", () => {
+	const project = Project.create({
+		name: 'Project',
+		draft: false,
+		path: '/fake/path'
+	});
+
+	const page = Page.create(
+		{
+			active: false,
+			id: 'page-1',
+			name: ''
+		},
+		{ project }
+	);
+
+	project.addPage(page);
+
+	const b = project.clone();
+	const [first, second] = b.getPages();
+
+	b.movePageAfter({
+		page: first,
+		targetPage: second
+	});
+
+	expect(b.getPages().map(p => p.getId())).toEqual([second.getId(), first.getId()]);
+
+	project.update(b);
+
+	expect(project.getPages().map(p => p.getId())).toEqual([second.getId(), first.getId()]);
+});

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -244,7 +244,7 @@ export class Project {
 
 		serialized.patternLibraries.forEach(p => project.addPatternLibrary(PatternLibrary.from(p)));
 
-		// Legacy bridge: Use page array order of no pagelist is found
+		// Legacy bridge: Use page array order if no pagelist is found
 		const pageList = serialized.pageList || serialized.pages.map(p => p.id);
 
 		serialized.pages
@@ -781,7 +781,7 @@ export class Project {
 			id: this.id,
 			name: this.name,
 			pages: this.pages.filter(Boolean).map(p => p.toJSON()),
-			pageList: this.pageList,
+			pageList: Array.from(this.pageList),
 			path: this.path,
 			patternLibraries: this.getPatternLibraries().map(p => p.toJSON()),
 			userStore: this.userStore.toJSON()
@@ -976,5 +976,11 @@ export class Project {
 		pageChanges.removed.forEach(change => this.removePage(change.before));
 		pageChanges.added.forEach(change => this.addPage(change.after));
 		pageChanges.changed.forEach(change => change.before.update(change.after));
+
+		this.pageList = b.pageList;
+	}
+
+	public clone(): Project {
+		return Project.from(this.toJSON());
 	}
 }

--- a/src/store/view-store.ts
+++ b/src/store/view-store.ts
@@ -879,6 +879,7 @@ export class ViewStore {
 		const item = this.editHistory.back();
 
 		if (!item) {
+			console.debug(`store.undo: no edit history item`);
 			return;
 		}
 
@@ -887,6 +888,7 @@ export class ViewStore {
 		const app = Model.AlvaApp.from(item.app, { sender: this.getSender() });
 
 		if (this.project && isEqual(project.toJSON(), this.project.toJSON())) {
+			console.debug(`store.undo: versions of project ${project.getName()} are equal`);
 			return;
 		}
 


### PR DESCRIPTION
Related to #644. 

Fixes bug where undo/redo would not work for page reordering operations.