### PR TITLE
fix: make sure new file menu action works

### DIFF
--- a/src/menu/file-menu.tsx
+++ b/src/menu/file-menu.tsx
@@ -35,7 +35,7 @@ export const fileMenu = (ctx: Types.MenuContext): Types.MenuItem => {
 						type: MessageType.CreateNewFileRequest,
 						id: uuid.v4(),
 						payload: {
-							replace: app.isActiveView(Types.AlvaView.SplashScreen)
+							replace: false
 						}
 					});
 				}


### PR DESCRIPTION
Cmd+N was broken on the Splashscreen, now it isn't