### PR TITLE
fix: do not blur window when iframe is active

### DIFF
--- a/src/renderer/create-listeners.ts
+++ b/src/renderer/create-listeners.ts
@@ -41,6 +41,11 @@ export function createListeners({ store }: { store: ViewStore }): void {
 	window.addEventListener(
 		'blur',
 		() => {
+			console.log(document.activeElement.tagName);
+			if (document.activeElement.tagName.toLowerCase() === 'iframe') {
+				return;
+			}
+
 			const project = store.getProject();
 
 			store.getSender().send({


### PR DESCRIPTION
Fixes a bug where the macOS main menu actions depending on an `AlvaApp` `Project` combination being known to the main process where not enabled / usable after clicking into the preview.