### PR TITLE
fix: open files on doubleclick

### DIFF
--- a/src/adapters/electron-adapter/electron-adapter.test.ts
+++ b/src/adapters/electron-adapter/electron-adapter.test.ts
@@ -83,3 +83,21 @@ test('reacts to pattern library update request', async () => {
 	server.sender.send(reqMsg);
 	expect((Matchers.updatePatternLibrary as any).handler).toHaveBeenCalledWith(reqMsg);
 });
+
+test('creates new splashscreen on start', async () => {
+	const server = await AlvaServer.fromHosts({} as any);
+
+	const adapter = new ElectronAdapter({ server });
+	await adapter.start();
+
+	expect((server as any).host.createWindow).toHaveBeenCalled();
+});
+
+test('create no splashscreen on start with filePath', async () => {
+	const server = await AlvaServer.fromHosts({} as any);
+
+	const adapter = new ElectronAdapter({ server });
+	await adapter.start({ filePath: 'some-file' });
+
+	expect((server as any).host.createWindow).not.toHaveBeenCalled();
+});

--- a/src/adapters/electron-adapter/electron-main-menu.ts
+++ b/src/adapters/electron-adapter/electron-main-menu.ts
@@ -96,4 +96,8 @@ export class ElectronMainMenu {
 			Electron.Menu.setApplicationMenu(menu);
 		});
 	}
+
+	public getApp(id: string): Model.AlvaApp | undefined {
+		return this.apps.get(id);
+	}
 }

--- a/src/bin/electron.ts
+++ b/src/bin/electron.ts
@@ -5,8 +5,8 @@ import * as Types from '../types';
 import * as Serde from '../sender/serde';
 import { ElectronAdapter } from '../adapters/electron-adapter';
 import * as Mobx from 'mobx';
-// import * as uuid from 'uuid';
-// import { MessageType as MT } from '../message';
+import * as uuid from 'uuid';
+import { MessageType as MT } from '../message';
 
 const importFresh = require('import-fresh');
 const clearModule = require('clear-module');
@@ -32,7 +32,9 @@ const onOpenFile = (e, path) => {
 };
 
 async function main(forced?: ForcedFlags): Promise<void> {
-	Electron.app.once('open-file', onOpenFile);
+	Electron.app.on('will-finish-launching', () => {
+		Electron.app.on('open-file', onOpenFile);
+	});
 
 	Electron.app.on('ready', () => {
 		state.ready = true;
@@ -58,20 +60,17 @@ async function main(forced?: ForcedFlags): Promise<void> {
 	await adapter.start();
 
 	// Use process.argv[1] if passed for win32
-	// await Mobx.when(() => state.ready);
-	// const fileToOpen = state.fileToOpen || (await electronHost.getFlags())._[0];
-
-	// if (fileToOpen) {
-	// 	alvaServer.sender.send({
-	// 		type: MT.OpenFileRequest,
-	// 		id: uuid.v4(),
-	// 		payload: {
-	// 			path: fileToOpen,
-	// 			replace: true,
-	// 			silent: false
-	// 		}
-	// 	});
-	// }
+	await Mobx.when(() => state.ready);
+	const fileToOpen = state.fileToOpen || (await electronHost.getFlags())._[0];
+	alvaServer.sender.send({
+		type: MT.OpenFileRequest,
+		id: uuid.v4(),
+		payload: {
+			path: fileToOpen,
+			replace: false,
+			silent: false
+		}
+	});
 
 	const onRestart = async () => {
 		const port = alvaServer.port;

--- a/src/bin/electron.ts
+++ b/src/bin/electron.ts
@@ -23,7 +23,7 @@ async function main(forced?: ForcedFlags): Promise<void> {
 
 	// Determine file to open
 	// Use process.argv[1] if passed for win32
-	const filePath = (await getPassedFile()) || (await electronHost.getFlags())._[0];
+	const filePath = (await getPassedFile()) || process.argv[1];
 
 	const localDataHost = await Hosts.LocalDataHost.fromHost(electronHost);
 
@@ -33,6 +33,10 @@ async function main(forced?: ForcedFlags): Promise<void> {
 	});
 
 	const adapter = new ElectronAdapter({ server: alvaServer });
+
+	electronHost.log(
+		`Starting ${filePath ? 'with' : 'without'} file ${filePath ? `at ${filePath}` : ''}`
+	);
 
 	await alvaServer.start();
 	await adapter.start({ filePath });

--- a/src/bin/electron.ts
+++ b/src/bin/electron.ts
@@ -62,15 +62,18 @@ async function main(forced?: ForcedFlags): Promise<void> {
 	// Use process.argv[1] if passed for win32
 	await Mobx.when(() => state.ready);
 	const fileToOpen = state.fileToOpen || (await electronHost.getFlags())._[0];
-	alvaServer.sender.send({
-		type: MT.OpenFileRequest,
-		id: uuid.v4(),
-		payload: {
-			path: fileToOpen,
-			replace: false,
-			silent: false
-		}
-	});
+
+	if (fileToOpen) {
+		alvaServer.sender.send({
+			type: MT.OpenFileRequest,
+			id: uuid.v4(),
+			payload: {
+				path: fileToOpen,
+				replace: false,
+				silent: false
+			}
+		});
+	}
 
 	const onRestart = async () => {
 		const port = alvaServer.port;

--- a/src/hosts/electron-host/electron-host.ts
+++ b/src/hosts/electron-host/electron-host.ts
@@ -8,6 +8,11 @@ import * as Electron from 'electron';
 import { createWindow } from './create-window';
 import { AlvaApp } from '../../model';
 import * as Mobx from 'mobx';
+import * as Message from '../../message';
+import * as ElectronLog from 'electron-log';
+
+ElectronLog.transports.console.level = 'info';
+ElectronLog.transports.file.level = 'silly';
 
 export interface ElectronHostInit {
 	process: NodeJS.Process;
@@ -113,7 +118,7 @@ export class ElectronHost implements Types.Host {
 	}
 
 	public async log(message?: unknown, ...optionalParams: unknown[]): Promise<void> {
-		console.log(message, ...optionalParams);
+		ElectronLog.log(message, ...optionalParams);
 	}
 
 	public async resolveFrom(base: Types.HostBase, ...paths: string[]): Promise<string> {
@@ -268,5 +273,9 @@ export class ElectronHost implements Types.Host {
 
 	public setSender(sender: Types.Sender) {
 		this.sender = sender;
+		this.sender.setLog((m: string, message: Message.Message) => {
+			this.log(m, message.type, message.id);
+			ElectronLog.silly(message);
+		});
 	}
 }

--- a/src/matchers/use-file-request.ts
+++ b/src/matchers/use-file-request.ts
@@ -7,12 +7,7 @@ import * as Model from '../model';
 
 export function useFileRequest({ dataHost, host }: T.MatcherContext): T.Matcher<M.UseFileRequest> {
 	return async m => {
-		const app = await host.getApp(m.appId || '');
-
-		if (!app) {
-			host.log(`useFileRequest: received message without resolveable app: ${m}`);
-			return;
-		}
+		const sender = (await host.getApp(m.appId || '')) || (await host.getSender());
 
 		const projectResult = await Persistence.parse<T.SerializedProject>(m.payload.contents);
 
@@ -22,7 +17,7 @@ export function useFileRequest({ dataHost, host }: T.MatcherContext): T.Matcher<
 			host.log(`useFileRequest: ${projectResult.error.message}`);
 
 			if (!silent) {
-				app.send({
+				sender.send({
 					type: M.MessageType.ShowError,
 					transaction: m.transaction,
 					id: m.id,
@@ -45,7 +40,7 @@ export function useFileRequest({ dataHost, host }: T.MatcherContext): T.Matcher<
 		if (result.status !== T.ProjectStatus.Ok) {
 			host.log(`useFileRequest: ${result.error.message}`);
 
-			app.send({
+			sender.send({
 				type: M.MessageType.ShowError,
 				transaction: m.transaction,
 				id: m.id,
@@ -105,7 +100,7 @@ export function useFileRequest({ dataHost, host }: T.MatcherContext): T.Matcher<
 				})
 		);
 
-		return app.send({
+		return sender.send({
 			type: M.MessageType.UseFileResponse,
 			id: m.id,
 			transaction: m.transaction,

--- a/src/message/message.ts
+++ b/src/message/message.ts
@@ -284,7 +284,7 @@ export type Maximize = EmptyEnvelope<MessageType.Maximize>;
 export type OpenExternalURL = Envelope<MessageType.OpenExternalURL, string>;
 export type OpenFileRequest = Envelope<
 	MessageType.OpenFileRequest,
-	{ path?: string; silent?: boolean; replace: boolean }
+	{ path?: string; silent?: boolean; replace: boolean; newWindow?: boolean }
 >;
 export type OpenFileResponse = Envelope<MessageType.OpenFileResponse, Types.ProjectPayload>;
 export type PageChange = Envelope<MessageType.PageChange, Types.PageChangePayload>;

--- a/src/sender/sender.ts
+++ b/src/sender/sender.ts
@@ -215,7 +215,7 @@ export class Sender implements Types.Sender {
 		const matchers = this.matchers.get(message.type);
 
 		if (matchers) {
-			matchers.forEach(matcher => matcher(message));
+			matchers.filter(m => typeof m === 'function').forEach(matcher => matcher(message));
 		}
 
 		const envelope = Serde.serialize(message);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,7 @@ export class AlvaServer implements Types.AlvaServer {
 	private ws: WS.Server;
 	public readonly dataHost: Types.DataHost;
 	public readonly host: Types.Host;
-	public readonly sender: Sender.Sender;
+	public sender: Sender.Sender;
 	public readonly port: number;
 	public readonly interface?: string;
 


### PR DESCRIPTION
## Proposed Changes
Now you can double-click files on your Finder or Explorer and Alva opens them.

To do:
- [x] Parse `open-file` correctly if Alva is not running yet
- [x] Parse `open-file` correctly if Alva is already running
- [x] Receive `OpenFileRequest` correctly in Electron

---

### Open while Alva is not running

**Status**:
Mac: ✅ @marionebl 
Windows: ✅ @marionebl 

  <details>
  <summary>Steps</summary>

  * 1. Be sure Alva is closed
  * 2. Double-Click on an Alva file
  * 3. See a new window open with project view
  * 4. No splashscreen window opens

  </details>

---

### Open while Alva is running: No window

**Status**
Mac: ✅ @marionebl 
Windows: **not applicable**

  <details>
  <summary>Steps</summary>

  * 1. Open Alva, so it shows the Splash Screen
  * 2. Close the Splash Screen window
  * 3. Double-Click on an Alva file
  * 4. See a new window open with project view
  * 5. No splashscreen window opens

  </details>

---

### Open while Alva is running: Splash Screen

**Status**
Mac: ✅ @marionebl 
Windows: ✅ @marionebl 

  <details>
  <summary>Steps</summary>

  * 1. Open Alva, so it shows the Splash Screen
  * 2. Double-Click on an Alva file
  * 3. See a new window open with project view
  * 4. Splash screen window is still there

  </details>

---

### Open while Alva is running: Opened Project

**Status**: 
Mac: ✅ @marionebl 
Windows: ✅ @marionebl 

  <details>
  <summary>Steps</summary>

  * 1. Be sure Alva is opened
  * 2. Open another project
  * 3. Double-Click on an Alva file
  * 4. See a new window open with project view

  </details>

---

### Open while Alva is running: Same Project

**Status**: 
Mac: ✅ @marionebl 
Windows: **not applicable**

  <details>
  <summary>Steps</summary>

  * 1. Open Project A in Alva.
  * 2. Go to Finder, double-click on the same Alva file A
  * 3. No new window opens

  </details>

---