### PR TITLE
fix: prevent pasting of alva models into property fields

### DIFF
--- a/src/matchers/paste.ts
+++ b/src/matchers/paste.ts
@@ -15,14 +15,14 @@ export function paste({ host }: T.MatcherContext): T.Matcher<M.Paste> {
 		const contents = await host.readClipboard();
 
 		if (!contents) {
-			host.log(`paste: non contents`);
+			host.log(`paste: no contents`);
 			return;
 		}
 
 		const message = Serde.deserialize(contents);
 
 		if (!message || message.type !== M.MessageType.Clipboard) {
-			host.log(`paste: clipboard message is no message`);
+			host.log(`paste: clipboard message is no clipboard message`);
 			return;
 		}
 


### PR DESCRIPTION
## Test cases

### Paste text into property field

Status: ✅ @tilmx

<details>

1. Create new file
2. Add text element to first page
3. Select "Text" in text element's `text` property
4. Hit `cmd+c`, thenn `cmd+v` 
5. See "TextText" in property field and preview

</details>

---

### Paste element into property field

Status: ✅ @tilmx  

<details>

1. Create new file
2. Add text element to first page
3. Select Element
4. Hit `cmd+c`
5. Focus text element 
6. Hit `cmd+v`
7. Nothing happens 💤 

</details>

---

### Paste element into development editor

Status: ✅ @tilmx 

<details>

1. Create new file
3. Select Element
4. Hit `cmd+c`
5. Open and focus development editor
6. Hit `cmd+v`
7. Nothing happens 💤 

</details>

---

### Paste text into development editor

Status: ✅ @tilmx 

<details>

1. Create new file
2. Open and focus development editor
3. Select some text in development editor
4. Hit `cmd+c` and `cmd+v`
7. Copied text is added at cursor position

</details>

---
