### PR TITLE
fix: get and execute element actions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	transform: {
 		"^.+\\.tsx?$": "ts-jest"
 	},
-	testRegex: "(\\.|/)(test|spec)\\.(jsx?|tsx?)$",
+	testRegex: "\\.test\\.tsx?$",
 	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
 	roots: ["src"]
 };

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -260,7 +260,6 @@ export class Project {
 		);
 
 		serialized.elementActions.forEach(elementAction => {
-			console.log(elementAction, '*******');
 			project.addElementAction(ElementAction.from(elementAction, { userStore }));
 		});
 

--- a/src/model/project.ts
+++ b/src/model/project.ts
@@ -260,6 +260,7 @@ export class Project {
 		);
 
 		serialized.elementActions.forEach(elementAction => {
+			console.log(elementAction, '*******');
 			project.addElementAction(ElementAction.from(elementAction, { userStore }));
 		});
 

--- a/src/preview/preview-store.test.ts
+++ b/src/preview/preview-store.test.ts
@@ -1,0 +1,68 @@
+import * as Model from '../model';
+import * as Types from '../types';
+import { ElementArea } from './element-area';
+import { getComponents } from './get-components';
+import { ViewStore } from '../store';
+import { Sender } from '../sender';
+import { PreviewStore, SyntheticComponents } from './preview-store';
+
+jest.mock('../sender');
+
+test('get and render element actions', () => {
+	const app = new Model.AlvaApp(Model.AlvaApp.Defaults, { sender: {} as any });
+	const history = new Model.EditHistory();
+	const sender = new Sender({
+		endpoint: ''
+	});
+
+	const store = new ViewStore({
+		app,
+		history,
+		sender
+	});
+
+	const project = Model.Project.create({
+		name: '',
+		path: '',
+		draft: true
+	});
+	store.setProject(project);
+
+	const mode = Types.PreviewDocumentMode.Static;
+	const inputMock = Model.Element.from(
+		{
+			model: Types.ModelName.Element,
+			dragged: false,
+			focused: false,
+			highlighted: false,
+			id: 'id',
+			name: 'name',
+			patternId: 'pattern-id',
+			placeholderHighlighted: false,
+			containerId: 'container-id',
+			contentIds: [],
+			open: false,
+			forcedOpen: false,
+			propertyValues: [['property-id', 'b']],
+			role: 'node',
+			selected: false
+		},
+		{ project }
+	);
+	project.addElement(inputMock);
+
+	const components = getComponents(project);
+	// tslint:disable-next-line:no-object-literal-type-assertion
+	const synthetics = {} as SyntheticComponents<{}>;
+
+	const previewStore = new PreviewStore({
+		mode,
+		components,
+		project,
+		synthetics,
+		selectionArea: new ElementArea(),
+		highlightArea: new ElementArea()
+	});
+
+	console.log(previewStore, '&&&&&&');
+});

--- a/src/preview/preview-store.ts
+++ b/src/preview/preview-store.ts
@@ -140,7 +140,6 @@ export class PreviewStore<V> {
 			if (!patternProperty) {
 				return renderProperties;
 			}
-
 			if (patternProperty.getType() === Types.PatternPropertyType.EventHandler) {
 				// Special case:
 				// the link property should render "click" event handlers as href, too
@@ -193,19 +192,23 @@ export class PreviewStore<V> {
 							return;
 						}
 					}
-
-					const elementAction = this.project.getElementActionById(
-						elementProperty.getValue() as string
-					);
-
-					if (!elementAction) {
+					const elementPropertyValues = elementProperty.getValue();
+					if (!elementPropertyValues) {
 						return;
 					}
+					const elementActions = Array.isArray(elementPropertyValues)
+						? elementPropertyValues.map(action => this.project.getElementActionById(action))
+						: new Array(elementPropertyValues);
 
-					elementAction.execute({
-						sender: this.app || this.sender,
-						project: this.getProject(),
-						event: e
+					elementActions.forEach((action: Model.ElementAction) => {
+						if (!action) {
+							return;
+						}
+						action.execute({
+							sender: this.app || this.sender,
+							project: this.getProject(),
+							event: e
+						});
 					});
 				};
 			} else {

--- a/src/preview/preview-store.ts
+++ b/src/preview/preview-store.ts
@@ -193,6 +193,7 @@ export class PreviewStore<V> {
 						}
 					}
 					const elementPropertyValues = elementProperty.getValue();
+
 					if (!elementPropertyValues) {
 						return;
 					}

--- a/src/preview/test.ts
+++ b/src/preview/test.ts
@@ -1,0 +1,71 @@
+import * as Model from '../model';
+import * as Types from '../types';
+import * as uuid from 'uuid';
+import { PreviewStore } from './preview-store';
+import { ElementArea } from './element-area';
+
+export function createAction({
+	project,
+	element
+}: {
+	project: Model.Project;
+	element: Model.Element;
+}): { action: Model.ElementAction } {
+	const action = Model.ElementAction.from(
+		{
+			model: Types.ModelName.ElementAction,
+			elementPropertyId: element.getId(),
+			id: uuid.v4(),
+			open: true,
+			payload: '',
+			payloadType: Types.ElementActionPayloadType.EventPayload,
+			storeActionId: uuid.v4(),
+			storePropertyId: uuid.v4()
+		},
+		{ userStore: project.getUserStore() }
+	);
+
+	project.addElementAction(action);
+
+	return { action };
+}
+
+export function createElementWithProject(): { project: Model.Project; element: Model.Element } {
+	const project = Model.Project.create({
+		name: 'test',
+		path: 'my/path',
+		draft: true
+	});
+
+	const library = project.getBuiltinPatternLibrary();
+	const linkPattern = library.getPatternByType(Types.PatternType.SyntheticLink);
+
+	const element = Model.Element.fromPattern(linkPattern, {
+		dragged: false,
+		contents: [],
+		project
+	});
+
+	project.addElement(element);
+
+	return { project, element };
+}
+
+export function getRenderProperties({
+	project,
+	element
+}: {
+	project: Model.Project;
+	element: Model.Element;
+}): { [key: string]: any } {
+	const previewStore = new PreviewStore({
+		mode: Types.PreviewDocumentMode.Static,
+		components: {},
+		project,
+		synthetics: {} as any,
+		selectionArea: new ElementArea(),
+		highlightArea: new ElementArea()
+	});
+
+	return previewStore.getProperties(element);
+}


### PR DESCRIPTION
## Proposed Changes
* `elementActions` can either receive a string containing the **action id** or an array containing several **action ids** to be executed.

### Test Case
1. Open a new Alva file
2. Connect the design kit
3. Drag the Input component into the element list
4. Click on the element list name
5. On the right sidebar choose **Handle Change**
5.1 Perform **Set Variable**
5.2 Give a name to your variable e.g. `da bomb` in the named field
5.3 Select **Payload > Value** in the **to** input field
5.4 Select `da bomb` on the **Value** field
6. Type some text in the component

#### Test File
[element-action-test.alva.zip](https://github.com/meetalva/alva/files/2667087/element-action-test.alva.zip)
