### PR TITLE
fix: ensure compat with new react typing versions

### DIFF
--- a/src/analyzer/react-utils/is-react-component-type.ts
+++ b/src/analyzer/react-utils/is-react-component-type.ts
@@ -6,7 +6,8 @@ const REACT_COMPONENT_TYPES = [
 	'ComponentClass',
 	'PureComponent',
 	'StatelessComponent',
-	'ComponentType'
+	'ComponentType',
+	'FunctionComponent'
 ];
 
 export function isReactComponentType(

--- a/src/bin/analyze.ts
+++ b/src/bin/analyze.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { performAnalysis } from '../matchers/perform-analysis';
+import * as Path from 'path';
+
+const yargsParser = require('yargs-parser');
+
+async function main() {
+	const flags = yargsParser(process.argv.slice(2));
+	const [rawPath] = flags._;
+	const path = Path.join(flags.cwd || process.cwd(), rawPath);
+
+	await performAnalysis(path, { previousLibrary: undefined });
+}
+
+main().catch(err => {
+	throw err;
+});


### PR DESCRIPTION
This fixes a bug where Alva would ignore components that should be analyzed. This was caused by `@types/react` introducing a new intermediary `FunctionComponent` type that needed to be added to our explicit matching dictionary.

This also includes a preliminary `analyze` cli entry for easier testing of analyzer-related effects.

Discovered the issue while working on meetalva/designkit#55
