### PR TITLE
perf: compile implementations only when needed

### DIFF
--- a/packages/core/src/analyzer/typescript-react-analyzer/typescript-react-analyzer.ts
+++ b/packages/core/src/analyzer/typescript-react-analyzer/typescript-react-analyzer.ts
@@ -110,7 +110,8 @@ async function analyzePatterns(context: {
 	const program = ts.createProgram(declarationPaths, options.config, compilerHost);
 
 	const project = new Tsa.Project({
-		tsConfigFilePath: optionsPath
+		tsConfigFilePath: optionsPath,
+		addFilesFromTsConfig: false
 	});
 
 	const analyzePattern = getPatternAnalyzer(program, project, context.options);

--- a/packages/core/src/analyzer/typescript-utils/get-tsa-export.ts
+++ b/packages/core/src/analyzer/typescript-utils/get-tsa-export.ts
@@ -18,6 +18,9 @@ export function getTsaExport(
 		sourcePathTSX
 	);
 
+	project.addExistingSourceFileIfExists(relSourcePath);
+	project.addExistingSourceFileIfExists(relSourcePathTSX);
+
 	const sourceFile = project
 		.getSourceFiles()
 		.find(


### PR DESCRIPTION
Improve analyzer performance a bit by compiling implementations only when needed.