### PR TITLE
chore: remove enum options when missing from updated property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
 
       - restore_cache:
           keys:
-          - v4-dependencies-<< parameters.key >>-{{ checksum "yarn.lock" }}
-          - v4-dependencies-<< parameters.key >>-
+          - v5-dependencies-<< parameters.key >>-{{ checksum "yarn.lock" }}
+          - v5-dependencies-<< parameters.key >>-
 
       - run:
           name: Install dependencies
@@ -28,7 +28,7 @@ commands:
             - node_modules
             - packages/core/node_modules
             - packages/tools/node_modules
-          key: v4-dependencies-<< parameters.key >>-{{ checksum "yarn.lock" }}
+          key: v5-dependencies-<< parameters.key >>-{{ checksum "yarn.lock" }}
 
       - run:
           name: Add npm bin to path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
 
       - run:
           name: Install dependencies
-          command: yarn
+          command: yarn install --frozen-lockfile
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ commands:
       key:
         type: string
     steps:
+
+      - run:
+          name: Install yarn
+          command: yarn global add yarn@1.12.3
+
       - checkout
 
       - restore_cache:

--- a/packages/core/src/model/pattern-property/enum-property.test.ts
+++ b/packages/core/src/model/pattern-property/enum-property.test.ts
@@ -1,0 +1,105 @@
+import { PatternEnumProperty, PatternEnumPropertyOption } from './enum-property';
+
+test('.update adds options', () => {
+	const propA = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: []
+	});
+
+	const propB = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: [
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'a'
+			}),
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'b'
+			}),
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'c'
+			})
+		]
+	});
+
+	propA.update(propB);
+	expect(propA.getOptions()).toEqual([
+		expect.objectContaining({ contextId: 'a' }),
+		expect.objectContaining({ contextId: 'b' }),
+		expect.objectContaining({ contextId: 'c' })
+	]);
+});
+
+test('.update updates options', () => {
+	const before = [
+		PatternEnumPropertyOption.fromDefaults({
+			id: 'a',
+			contextId: 'a',
+			value: 'a'
+		}),
+		PatternEnumPropertyOption.fromDefaults({
+			id: 'b',
+			contextId: 'b',
+			value: 'b'
+		}),
+		PatternEnumPropertyOption.fromDefaults({
+			id: 'c',
+			contextId: 'c',
+			value: 'c'
+		})
+	];
+
+	const after = before.map(b => PatternEnumPropertyOption.from(b.toJSON())).map(b => {
+		b.setValue((b.getValue() as string).repeat(2));
+		return b;
+	});
+
+	const propA = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: before
+	});
+
+	const propB = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: after
+	});
+
+	propA.update(propB);
+	expect(propA.getOptions()).toEqual([
+		expect.objectContaining({ contextId: 'a' }),
+		expect.objectContaining({ contextId: 'b' }),
+		expect.objectContaining({ contextId: 'c' })
+	]);
+});
+
+test('.update removes options', () => {
+	const propA = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: [
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'a'
+			}),
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'b'
+			}),
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'c'
+			})
+		]
+	});
+
+	const propB = PatternEnumProperty.fromDefaults({
+		contextId: 'a',
+		options: [
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'a'
+			}),
+			PatternEnumPropertyOption.fromDefaults({
+				contextId: 'c'
+			})
+		]
+	});
+
+	expect(propA.getOptionByContextId('b')).not.toBe(undefined);
+	propA.update(propB);
+	expect(propA.getOptionByContextId('b')).toBe(undefined);
+});


### PR DESCRIPTION
## Remove an enum property option

## Tests

Status: ✅ @tilmx   

<details>

1. Open Alva
2. Create new file
3. Connect the Design Kit
5. Start designkit build via `tsc -w`
6. Remove `Primary` enum member from `ButtonOrder`
7. Update the pattern library in Alva
8. Add a `Button` to the Element List
9. Only the `Secondary` option should be visible in the `order` select
</details>