### PR TITLE
fix: do not coerce optional prop values to empty strings

### DIFF
--- a/packages/core/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
+++ b/packages/core/src/analyzer/typescript-react-analyzer/property-analyzer/property-analyzer.ts
@@ -116,8 +116,8 @@ function createUnknownProperty(
 		removeComments: true
 	});
 
-	const print = (node: Ts.Declaration) => {
-		return printer.printNode(Ts.EmitHint.Unspecified, node, node.getSourceFile());
+	const print = (node?: Ts.Declaration) => {
+		return node ? printer.printNode(Ts.EmitHint.Unspecified, node, node.getSourceFile()) : '';
 	};
 
 	return {

--- a/packages/core/src/model/pattern-property/string-property.test.ts
+++ b/packages/core/src/model/pattern-property/string-property.test.ts
@@ -1,0 +1,54 @@
+import { PatternStringProperty } from './string-property';
+
+test('coerces undefined to empty string if required', () => {
+	const property = PatternStringProperty.fromDefaults({
+		required: true
+	});
+
+	const actual = property.coerceValue(undefined);
+	expect(actual).toBe('');
+});
+
+test('coerces null to empty string if required', () => {
+	const property = PatternStringProperty.fromDefaults({
+		required: true
+	});
+
+	const actual = property.coerceValue(null);
+	expect(actual).toBe('');
+});
+
+test('coerces undefined to undefined if optional', () => {
+	const property = PatternStringProperty.fromDefaults();
+
+	const actual = property.coerceValue(undefined);
+	expect(actual).toBeUndefined();
+});
+
+test('coerces null to undefined if optional', () => {
+	const property = PatternStringProperty.fromDefaults();
+
+	const actual = property.coerceValue(null);
+	expect(actual).toBeUndefined();
+});
+
+test('coerces number to string represenation', () => {
+	const property = PatternStringProperty.fromDefaults();
+
+	const actual = property.coerceValue(1);
+	expect(actual).toBe('1');
+});
+
+test('coerces NaN to undefined', () => {
+	const property = PatternStringProperty.fromDefaults();
+
+	const actual = property.coerceValue(parseInt('thing', 10));
+	expect(actual).toBe(undefined);
+});
+
+test('coerces boolean to string representation', () => {
+	const property = PatternStringProperty.fromDefaults();
+
+	const actual = property.coerceValue(true);
+	expect(actual).toBe('true');
+});

--- a/packages/core/src/model/pattern-property/string-property.ts
+++ b/packages/core/src/model/pattern-property/string-property.ts
@@ -1,5 +1,11 @@
-import { deserializeOrigin, PatternPropertyBase, serializeOrigin } from './property-base';
+import {
+	deserializeOrigin,
+	PatternPropertyBase,
+	serializeOrigin,
+	PatternPropertyInit
+} from './property-base';
 import * as Types from '../../types';
+import uuid = require('uuid');
 
 /**
  * A string property is a property that supports text only.
@@ -10,6 +16,26 @@ import * as Types from '../../types';
  */
 export class PatternStringProperty extends PatternPropertyBase<string | undefined> {
 	public readonly type = Types.PatternPropertyType.String;
+
+	public static Defaults(
+		mixins?: Partial<PatternPropertyInit<string>>
+	): PatternPropertyInit<string> {
+		return {
+			contextId: 'stringProperty',
+			defaultValue: 'Text',
+			description: 'A string property',
+			example: '',
+			group: '',
+			hidden: false,
+			id: uuid.v4(),
+			inputType: Types.PatternPropertyInputType.Default,
+			label: 'String Property',
+			origin: Types.PatternPropertyOrigin.UserProvided,
+			propertyName: 'stringProperty',
+			required: false,
+			...mixins
+		};
+	}
 
 	public static from(serialized: Types.SerializedPatternStringProperty): PatternStringProperty {
 		return new PatternStringProperty({
@@ -28,13 +54,32 @@ export class PatternStringProperty extends PatternPropertyBase<string | undefine
 		});
 	}
 
-	// tslint:disable-next-line:no-any
-	public coerceValue(value: any): any {
-		if (value === null || value === undefined || value === '') {
-			return '';
-		} else {
+	public static fromDefaults(
+		mixins?: Partial<PatternPropertyInit<string>>
+	): PatternStringProperty {
+		return new PatternStringProperty(PatternStringProperty.Defaults(mixins));
+	}
+
+	public coerceValue(value: unknown): string | undefined {
+		if (typeof value === 'string') {
+			return value;
+		}
+
+		const empty = this.required ? '' : undefined;
+
+		if (typeof value === 'undefined' || value === null) {
+			return empty;
+		}
+
+		if (typeof value === 'number' && !Number.isNaN(value)) {
 			return String(value);
 		}
+
+		if (typeof value === 'boolean') {
+			return value ? 'true' : 'false';
+		}
+
+		return empty;
 	}
 
 	public toJSON(): Types.SerializedPatternStringProperty {

--- a/packages/core/src/model/pattern-property/unknown-property.test.ts
+++ b/packages/core/src/model/pattern-property/unknown-property.test.ts
@@ -1,0 +1,54 @@
+import { PatternUnknownProperty } from './unknown-property';
+
+test('coerces undefined to empty string if required', () => {
+	const property = PatternUnknownProperty.fromDefaults({
+		required: true
+	});
+
+	const actual = property.coerceValue(undefined);
+	expect(actual).toBe('');
+});
+
+test('coerces null to empty string if required', () => {
+	const property = PatternUnknownProperty.fromDefaults({
+		required: true
+	});
+
+	const actual = property.coerceValue(null);
+	expect(actual).toBe('');
+});
+
+test('coerces undefined to undefined if optional', () => {
+	const property = PatternUnknownProperty.fromDefaults();
+
+	const actual = property.coerceValue(undefined);
+	expect(actual).toBeUndefined();
+});
+
+test('coerces null to undefined if optional', () => {
+	const property = PatternUnknownProperty.fromDefaults();
+
+	const actual = property.coerceValue(null);
+	expect(actual).toBeUndefined();
+});
+
+test('coerces number to undefined', () => {
+	const property = PatternUnknownProperty.fromDefaults();
+
+	const actual = property.coerceValue(1);
+	expect(actual).toBeUndefined();
+});
+
+test('coerces NaN to undefined', () => {
+	const property = PatternUnknownProperty.fromDefaults();
+
+	const actual = property.coerceValue(parseInt('thing', 10));
+	expect(actual).toBeUndefined();
+});
+
+test('coerces boolean to undefined', () => {
+	const property = PatternUnknownProperty.fromDefaults();
+
+	const actual = property.coerceValue(true);
+	expect(actual).toBe(undefined);
+});

--- a/packages/core/src/model/pattern-property/unknown-property.ts
+++ b/packages/core/src/model/pattern-property/unknown-property.ts
@@ -27,7 +27,7 @@ export class PatternUnknownProperty extends PatternPropertyBase<unknown | undefi
 		this.typeText = init.typeText;
 	}
 
-	public static Defaults(mixin: Partial<PatternUnknownPropertyInit>): PatternUnknownPropertyInit {
+	public static Defaults(mixin?: Partial<PatternUnknownPropertyInit>): PatternUnknownPropertyInit {
 		return {
 			contextId: 'unknown',
 			group: '',
@@ -61,19 +61,21 @@ export class PatternUnknownProperty extends PatternPropertyBase<unknown | undefi
 		});
 	}
 
-	public static fromDefaults(mixin: Partial<PatternUnknownPropertyInit>): PatternUnknownProperty {
+	public static fromDefaults(mixin?: Partial<PatternUnknownPropertyInit>): PatternUnknownProperty {
 		return new PatternUnknownProperty(PatternUnknownProperty.Defaults(mixin));
 	}
 
-	public coerceValue(value: any): string | undefined {
-		if (typeof value === 'undefined') {
-			return;
+	public coerceValue(value: unknown): unknown | undefined {
+		const empty = this.required ? '' : undefined;
+
+		if (typeof value !== 'string') {
+			return empty;
 		}
 
 		try {
 			return JSON5.parse(value);
 		} catch (err) {
-			return;
+			return empty;
 		}
 	}
 


### PR DESCRIPTION
## Test

Status: ❓   

<details>

1. Open Alva
2. Create new file
3. Connect the internal "circles" library
4. Add a "Copy" element
5. Add a "Text" element as child
6. No error should be thrown

</details>