### PR TITLE
perf: cut down on app weight by using ncc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,9 @@ jobs:
       - setup:
           key: linux
 
-      - run: lerna run test --stream
+      - run:
+          name: Run unit tests
+          command: lerna run test --stream
 
   lint:
     docker:
@@ -105,7 +107,9 @@ jobs:
       - setup:
           key: linux
 
-      - run: lerna run compile --stream
+      - run:
+          name: Compile with tsc
+          command: lerna run compile --stream
 
       - persist_to_workspace:
           root: packages/core
@@ -122,7 +126,9 @@ jobs:
       - setup:
           key: linux
 
-      - run: lerna run compile:ncc --stream
+      - run:
+          name: Compile with ncc
+          command: lerna run compile:ncc --stream
 
       - persist_to_workspace:
           root: packages/core
@@ -139,7 +145,9 @@ jobs:
       - setup:
           key: linux
 
-      - run: lerna run bundle --stream
+      - run:
+          name: Create browser scripts
+          command: lerna run bundle --stream
 
       - persist_to_workspace:
           root: packages/core
@@ -159,8 +167,13 @@ jobs:
       - attach_workspace:
           at: packages/core
 
-      - run: lerna run static --stream
-      - run: alva-deploy --project packages/core/.static
+      - run:
+          name: Create static build
+          command: lerna run static --stream
+
+      - run:
+          name: Deploy to static hosting
+          command: alva-deploy --project packages/core/.static
 
   trigger:
     docker:
@@ -193,10 +206,6 @@ jobs:
           at: packages/core
 
       - run:
-          name: List files
-          command: ls -la
-
-      - run:
           name: Copy Scripts
           command: lerna run copy:scripts
 
@@ -218,16 +227,12 @@ jobs:
           at: packages/core
 
       - run:
-          name: List files
-          command: ls -la
-
-      - run:
           name: Copy Scripts
           command: lerna run copy:scripts
 
       - run:
           name: Publish Release
-          command: alva-release --project packages/core/nccbuild
+          command: alva-release --debug --project packages/core/nccbuild
 
   windows:
     docker:
@@ -241,10 +246,6 @@ jobs:
 
       - attach_workspace:
           at: packages/core
-
-      - run:
-          name: List files
-          command: ls -la
 
       - run:
           name: Copy Scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,13 +129,9 @@ jobs:
       - attach_workspace:
           at: packages/core
 
-      - run: cat packages/core/package.ncc.json
-
       - run:
           name: Compile with ncc
           command: lerna run compile:ncc --stream
-
-      - run: cat packages/core/nccbuild/package.json
 
       - persist_to_workspace:
           root: packages/core
@@ -193,8 +189,6 @@ jobs:
       - run:
           name: Trigger Release
           command: alva-trigger --project packages/core
-
-      - run: cat packages/core/package.ncc.json
 
       - persist_to_workspace:
           root: packages/core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - persist_to_workspace:
           root: packages/core
           paths:
-              - build
+              - build/scripts
 
   static:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - persist_to_workspace:
           root: packages/core
           paths:
-              - package.json
+              - package.ncc.json
 
   macos:
     macos:
@@ -191,6 +191,10 @@ jobs:
 
       - attach_workspace:
           at: packages/core
+
+      - run:
+          name: List files
+          command: ls -la
 
       - run:
           name: Copy Scripts
@@ -214,6 +218,10 @@ jobs:
           at: packages/core
 
       - run:
+          name: List files
+          command: ls -la
+
+      - run:
           name: Copy Scripts
           command: cp -r build/scripts nccbuild/scripts
 
@@ -233,6 +241,10 @@ jobs:
 
       - attach_workspace:
           at: packages/core
+
+      - run:
+          name: List files
+          command: ls -la
 
       - run:
           name: Copy Scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,23 @@ jobs:
           paths:
               - build
 
+  ncc:
+    docker:
+      - image: circleci/node:8
+
+    working_directory: ~/repo
+
+    steps:
+      - setup:
+          key: linux
+
+      - run: lerna run compile:ncc --stream
+
+      - persist_to_workspace:
+          root: packages/core
+          paths:
+              - nccbuild
+
   bundle:
     docker:
       - image: circleci/node:8
@@ -176,8 +193,12 @@ jobs:
           at: packages/core
 
       - run:
+          name: Copy Scripts
+          command: cp -r build/scripts nccbuild/scripts
+
+      - run:
           name: Publish Release
-          command: alva-release --project packages/core
+          command: alva-release --project packages/core/nccbuild
 
   linux:
     docker:
@@ -193,8 +214,12 @@ jobs:
           at: packages/core
 
       - run:
+          name: Copy Scripts
+          command: cp -r build/scripts nccbuild/scripts
+
+      - run:
           name: Publish Release
-          command: alva-release --project packages/core
+          command: alva-release --project packages/core/nccbuild
 
   windows:
     docker:
@@ -210,8 +235,12 @@ jobs:
           at: packages/core
 
       - run:
+          name: Copy Scripts
+          command: cp -r build/scripts nccbuild/scripts
+
+      - run:
           name: Publish Release
-          command: alva-release --project packages/core -- --win
+          command: alva-release --project packages/core/nccbuild -- --win
 
 
 workflows:
@@ -224,6 +253,7 @@ workflows:
       - lint
       - bundle
       - compile
+      - ncc
       - static:
           requires:
             - test
@@ -235,20 +265,20 @@ workflows:
             - install_macos
             - test
             - lint
-            - compile
+            - ncc
             - bundle
             - trigger
       - linux:
           requires:
             - test
             - lint
-            - compile
+            - ncc
             - bundle
             - trigger
       - windows:
           requires:
             - test
             - lint
-            - compile
+            - ncc
             - bundle
             - trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,9 +126,13 @@ jobs:
       - setup:
           key: linux
 
+      - run: cat packages/core/package.ncc.json
+
       - run:
           name: Compile with ncc
           command: lerna run compile:ncc --stream
+
+      - run: cat packages/core/nccbuild/package.json
 
       - persist_to_workspace:
           root: packages/core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
 
       - run:
           name: Copy Scripts
-          command: cp -r build/scripts nccbuild/scripts
+          command: lerna run copy:scripts
 
       - run:
           name: Publish Release
@@ -223,7 +223,7 @@ jobs:
 
       - run:
           name: Copy Scripts
-          command: cp -r build/scripts nccbuild/scripts
+          command: lerna run copy:scripts
 
       - run:
           name: Publish Release
@@ -248,7 +248,7 @@ jobs:
 
       - run:
           name: Copy Scripts
-          command: cp -r build/scripts nccbuild/scripts
+          command: lerna run copy:scripts
 
       - run:
           name: Publish Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,9 @@ jobs:
       - setup:
           key: linux
 
+      - attach_workspace:
+          at: packages/core
+
       - run: cat packages/core/package.ncc.json
 
       - run:
@@ -190,6 +193,8 @@ jobs:
       - run:
           name: Trigger Release
           command: alva-trigger --project packages/core
+
+      - run: cat packages/core/package.ncc.json
 
       - persist_to_workspace:
           root: packages/core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,9 @@ workflows:
       - lint
       - bundle
       - compile
-      - ncc
+      - ncc:
+          requires:
+            - trigger
       - static:
           requires:
             - test
@@ -279,18 +281,15 @@ workflows:
             - lint
             - ncc
             - bundle
-            - trigger
       - linux:
           requires:
             - test
             - lint
             - ncc
             - bundle
-            - trigger
       - windows:
           requires:
             - test
             - lint
             - ncc
             - bundle
-            - trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
 
       - run:
           name: Publish Release
-          command: alva-release --debug --project packages/core/nccbuild
+          command: alva-release --project packages/core/nccbuild
 
   windows:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+nccbuild
 dist
 node_modules
 *.log

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,3 @@
+monaco-editor/dev
+monaco-editor/min
+monaco-editor/min-maps

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,16 +2,16 @@
   "name": "@meetalva/core",
   "version": "0.9.0",
   "description": "Create living prototypes with code components",
-  "main": "./build/bin/electron.js",
   "bin": {
     "alva": "./bin/alva.js"
   },
   "scripts": {
     "alva": "node bin/alva",
     "compile": "tsc --project .",
+    "compile:ncc": "yarn ncc build src/bin/electron.ts -e electron -e monaco-editor -e webpack -e ws -o nccbuild && ncp package.ncc.json nccbuild/package.json",
     "bundle": "webpack --production",
     "build:clean": "npm run clean && npm run build",
-    "build:electron": "electron-builder",
+    "build:electron": "electron-builder --project nccbuild",
     "clean": "rm -rf build && rm -rf dist",
     "lint": "tslint --project . -c tslint.json 'src/**/*.ts'",
     "release": "electron-builder --publish always",
@@ -33,60 +33,6 @@
   "bugs": {
     "url": "https://github.com/meetalva/alva/issues"
   },
-  "build": {
-    "appId": "io.github.meetalva",
-    "generateUpdatesFilesForAllChannels": true,
-    "npmRebuild": false,
-    "productName": "Alva",
-    "copyright": "Copyright (c) 2017-present SinnerSchrader Deutschland GmbH",
-    "files": [
-      "build/**/*",
-      "package.json"
-    ],
-    "directories": {
-      "buildResources": "src/resources",
-      "output": "dist"
-    },
-    "mac": {
-      "category": "public.app-category.graphics-design",
-      "target": [
-        "dmg",
-        "zip"
-      ]
-    },
-    "nsis": {
-      "artifactName": "${productName}-${version}.${ext}",
-      "oneClick": false,
-      "perMachine": true,
-      "allowElevation": true,
-      "allowToChangeInstallationDirectory": true
-    },
-    "portable": {
-      "artifactName": "${productName}-portable-${version}.${ext}"
-    },
-    "linux": {
-      "artifactName": "${productName}-${version}.${ext}",
-      "executableName": "Alva",
-      "target": [
-        "appimage",
-        "snap",
-        "deb"
-      ]
-    },
-    "win": {
-      "target": [
-        "portable",
-        "nsis"
-      ]
-    },
-    "fileAssociations": {
-      "ext": "alva",
-      "name": "Alva",
-      "icon": "document.icns",
-      "role": "Editor",
-      "isPackage": true
-    }
-  },
   "standard-version": {
     "scripts": {
       "prebump": "rm -f package-lock.json"
@@ -96,6 +42,7 @@
     "@patternplate/cli": "^3.2.4",
     "@patternplate/render-styled-components": "2.5.18",
     "@types/jest": "22.2.2",
+    "@zeit/ncc": "^0.8.1",
     "concurrently": "3.5.1",
     "css-loader": "1.0.0",
     "electron": "^4.0.0",
@@ -106,6 +53,7 @@
     "jest-util": "^23.4.0",
     "mobx-react-devtools": "6.0.3",
     "monaco-editor-webpack-plugin": "1.4.0",
+    "ncp": "^2.0.0",
     "prettier": "1.12.0",
     "react-testing-library": "5.4.0",
     "style-loader": "0.21.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "alva": "node bin/alva",
+    "copy:scripts": "ncp build/scripts nccbuild/scripts",
     "compile": "tsc --project .",
     "compile:ncc": "yarn ncc build src/bin/electron.ts -e electron -e monaco-editor -e webpack -e ws -o nccbuild && ncp package.ncc.json nccbuild/package.json",
     "bundle": "webpack --production",

--- a/packages/core/package.ncc.json
+++ b/packages/core/package.ncc.json
@@ -59,9 +59,8 @@
 			"isPackage": true
 		}
 	},
-	"// dependencies": "Dependencies that are externals when compiling with ncc",
+	"// dependencies": "Dependencies that are externals and required in main process when compiling with ncc",
 	"dependencies": {
-		"monaco-editor": "0.13.1",
 		"webpack": "^4.28.2",
 		"ws": "5.1.1"
 	},

--- a/packages/core/package.ncc.json
+++ b/packages/core/package.ncc.json
@@ -1,0 +1,69 @@
+{
+	"name": "@meetalva/core",
+	"version": "0.9.0",
+	"description": "Create living prototypes with code components",
+	"main": "./index.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/meetalva/alva.git"
+	},
+	"author": {
+		"email": "hey@meetalva.io",
+		"name": "Meet Alva Team",
+		"url": "https://meetalva.io/"
+	},
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/meetalva/alva/issues"
+	},
+	"build": {
+		"appId": "io.github.meetalva",
+		"generateUpdatesFilesForAllChannels": true,
+		"npmRebuild": false,
+		"productName": "Alva",
+		"copyright": "Copyright (c) 2017-present SinnerSchrader Deutschland GmbH",
+		"files": [
+			"**/*"
+		],
+		"directories": {
+			"buildResources": "src/resources",
+			"output": "dist"
+		},
+		"mac": {
+			"category": "public.app-category.graphics-design",
+			"target": ["dmg", "zip"]
+		},
+		"nsis": {
+			"artifactName": "${productName}-${version}.${ext}",
+			"oneClick": false,
+			"perMachine": true,
+			"allowElevation": true,
+			"allowToChangeInstallationDirectory": true
+		},
+		"portable": {
+			"artifactName": "${productName}-portable-${version}.${ext}"
+		},
+		"linux": {
+			"artifactName": "${productName}-${version}.${ext}",
+			"executableName": "Alva",
+			"target": ["appimage", "snap", "deb"]
+		},
+		"win": {
+			"target": ["portable", "nsis"]
+		},
+		"fileAssociations": {
+			"ext": "alva",
+			"name": "Alva",
+			"icon": "document.icns",
+			"role": "Editor",
+			"isPackage": true
+		}
+	},
+	"// dependencies": "Dependencies that are externals when compiling with ncc",
+	"dependencies": {
+		"monaco-editor": "0.13.1",
+		"webpack": "^4.28.2",
+		"ws": "5.1.1"
+	},
+	"homepage": "https://meetalva.github.io/"
+}

--- a/packages/core/src/preview/preview.ts
+++ b/packages/core/src/preview/preview.ts
@@ -17,7 +17,7 @@ export interface Renderer<T> {
 declare global {
 	interface Window {
 		// tslint:disable-next-line:no-any
-		previewRenderer: Renderer<any>;
+		previewRenderer: any;
 		rpc: {
 			getDocumentSize(): Promise<{ width: number; height: number }>;
 			// tslint:disable-next-line:no-any

--- a/packages/core/src/server/routes/scripts.ts
+++ b/packages/core/src/server/routes/scripts.ts
@@ -1,29 +1,37 @@
 import * as Express from 'express';
-import * as Fs from 'fs';
 import * as Types from '../../types';
+import * as Path from 'path';
 
 export function scriptsRouteFactory(server: Types.AlvaServer): Express.RequestHandler {
 	return async function scriptsRoute(req: Express.Request, res: Express.Response): Promise<void> {
-		const candidate = await server.host.resolveFrom(
-			Types.HostBase.Source,
-			'scripts',
-			req.params.path
+		const results = await Promise.all(
+			[
+				Path.resolve(__dirname, '..', 'scripts', req.params.path), //  built via ncc
+				Path.resolve(__dirname, '..', '..', 'scripts', req.params.path) // other envs
+			].map(async candidate => {
+				try {
+					return { error: null, file: await server.host.readFile(candidate) };
+				} catch (error) {
+					return { error, file: null };
+				}
+			})
 		);
 
-		try {
-			const file = await server.host.readFile(candidate);
-			res.type('js').send(file.contents);
-		} catch (err) {
-			server.host.log(err);
+		const result = results.find(
+			(r): r is { error: null; file: Types.HostFile } => r.error === null
+		);
 
-			switch (err.code) {
-				case 'ENOENT': {
-					res.sendStatus(404);
-					break;
-				}
-				default:
-					res.sendStatus(500);
-			}
+		if (result) {
+			res.send(result.file.buffer);
+			return;
+		}
+
+		server.host.log(results.map(r => r.error.message).join('\n'));
+
+		if (results.every(r => r.error.code === 'ENOENT')) {
+			res.sendStatus(404);
+		} else {
+			res.sendStatus(500);
 		}
 	};
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -15,5 +15,6 @@
 		"rootDir": "src",
 		"target": "es2017",
 		"sourceMap": true
-	}
+	},
+	"include": ["src"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,6 @@
 		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": false,
 		"strict": true,
-		"declaration": true,
 		"downlevelIteration": true,
 		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -3,6 +3,8 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const yargs = require('yargs-parser');
 const flags = yargs(process.argv.slice(2));
 
+const out = flags.out ? flags.out : 'build';
+
 module.exports = {
 	mode: flags.production ? 'production' : 'development',
 	devtool: flags.production || flags.sourceMaps ? 'source-maps' : 'eval',
@@ -36,7 +38,7 @@ module.exports = {
 	plugins: [
 		new MonacoWebpackPlugin({
 			languages: ['typescript', 'json'],
-			output: '/scripts/'
+			output: ''
 		})
 	],
 	externals: {
@@ -46,7 +48,7 @@ module.exports = {
 		filename: '[name].js',
 		library: '[name]',
 		libraryTarget: 'window',
-		path: Path.join(__dirname, 'build', 'scripts'),
+		path: Path.join(__dirname, out, 'scripts'),
 		publicPath: '/scripts/'
 	}
 };

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -19,9 +19,9 @@ async function main(cli) {
 
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 
-	if (branch !== 'master' && !process.env.CIRCLE_PULL_REQUEST) {
-		console.log(`${prefix}skipping, not on master or pr`);
-	}
+	const publish = (branch === 'master' || !process.env.CIRCLE_PULL_REQUEST)
+		? 'always'
+		: 'never';
 
 	const current = semverUtils.parse(manifest.version);
 	const channel = current.release ? current.release.split('.')[0] : 'stable';
@@ -55,7 +55,7 @@ async function main(cli) {
 	}
 
 	if (!cli.dryRun) {
-		await execa('electron-builder', ['--publish', 'always', ...cli._], {
+		await execa('electron-builder', ['--publish', publish, ...cli._], {
 			cwd: projectPath,
 			stdio: 'inherit',
 			env: {

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -17,6 +17,10 @@ async function main(cli) {
 	const projectPath = Path.resolve(process.cwd(), cli.project);
 	const manifest = require(Path.join(projectPath, 'package.json'));
 
+	if (cli.debug) {
+		console.log('in:', manifest);
+	}
+
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 
 	const publish = (branch === 'master' || !process.env.CIRCLE_PULL_REQUEST)
@@ -51,7 +55,7 @@ async function main(cli) {
 	}
 
 	if (cli.debug) {
-		console.log(manifest);
+		console.log('out:', manifest);
 	}
 
 	if (!cli.dryRun) {

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -51,7 +51,11 @@ async function main(cli) {
 	if (!cli.dryRun) {
 		await execa('electron-builder', ['--publish', 'always', ...cli._], {
 			cwd: projectPath,
-			stdio: 'inherit'
+			stdio: 'inherit',
+			env: {
+				PUBLISH_FOR_PULL_REQUEST: typeof process.env.GH_TOKEN !== 'undefined',
+				CSC_FOR_PULL_REQUEST: typeof process.env.CSC_KEY_PASSWORD !== 'undefined' && typeof process.env.CSC_LINK !== 'undefined',
+			}
 		});
 	}
 }

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -58,7 +58,7 @@ async function main(cli) {
 		console.log('out:', manifest);
 	}
 
-	console.log(`${prefix}: 'electron-builder' ${['--publish', publish, ...cli._].join(' ')}`);
+	console.log(`electron-builder ${['--publish', publish, ...cli._].join(' ')}`);
 
 	if (!cli.dryRun) {
 		await execa('electron-builder', ['--publish', publish, ...cli._], {

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -58,6 +58,9 @@ async function main(cli) {
 		console.log('out:', manifest);
 	}
 
+
+	console.log(`${prefix}: 'electron-builder' ${['--publish', publish, ...cli._].join(' ')}`);
+
 	if (!cli.dryRun) {
 		await execa('electron-builder', ['--publish', publish, ...cli._], {
 			cwd: projectPath,

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -23,7 +23,7 @@ async function main(cli) {
 
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 
-	const publish = (branch === 'master' || !process.env.CIRCLE_PULL_REQUEST)
+	const publish = (branch === 'master' || process.env.CIRCLE_PULL_REQUEST)
 		? 'always'
 		: 'never';
 
@@ -57,7 +57,6 @@ async function main(cli) {
 	if (cli.debug) {
 		console.log('out:', manifest);
 	}
-
 
 	console.log(`${prefix}: 'electron-builder' ${['--publish', publish, ...cli._].join(' ')}`);
 

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -20,6 +20,12 @@ async function main(cli) {
 	const current = semverUtils.parse(manifest.version);
 	const channel = current.release ? current.release.split('.')[0] : 'stable';
 
+	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
+
+	if (branch !== 'master' && !process.env.CIRCLE_PULL_REQUEST) {
+		console.log(`${prefix}skipping, not on master or pr`);
+	}
+
 	manifest.build.publish = [
 		...(manifest.build.publish || []),
 		{

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -17,14 +17,14 @@ async function main(cli) {
 	const projectPath = Path.resolve(process.cwd(), cli.project);
 	const manifest = require(Path.join(projectPath, 'package.json'));
 
-	const current = semverUtils.parse(manifest.version);
-	const channel = current.release ? current.release.split('.')[0] : 'stable';
-
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 
 	if (branch !== 'master' && !process.env.CIRCLE_PULL_REQUEST) {
 		console.log(`${prefix}skipping, not on master or pr`);
 	}
+
+	const current = semverUtils.parse(manifest.version);
+	const channel = current.release ? current.release.split('.')[0] : 'stable';
 
 	manifest.build.publish = [
 		...(manifest.build.publish || []),

--- a/packages/tools/alva-release.js
+++ b/packages/tools/alva-release.js
@@ -20,23 +20,35 @@ async function main(cli) {
 	const current = semverUtils.parse(manifest.version);
 	const channel = current.release ? current.release.split('.')[0] : 'stable';
 
-	manifest.build.publish = [...(manifest.build.publish || []), {
-		provider: 'github',
-		releaseType: channel === 'alpha' ? 'prerelease' : 'draft'
-	}];
+	manifest.build.publish = [
+		...(manifest.build.publish || []),
+		{
+			provider: 'github',
+			releaseType: channel === 'alpha' ? 'prerelease' : 'draft'
+		}
+	];
 
 	if (!cli.dryRun) {
 		await writeFile(Path.join(projectPath, 'package.json'), JSON.stringify(manifest, null, '  '));
+	}
 
-		if (channel === 'alpha') {
-			manifest.build.productName = `Alva Canary`;
-			await execa.shell('cp ./src/resources/alpha/* ./src/resources', { cwd: projectPath });
-		}
+	if (channel === 'alpha') {
+		manifest.build.productName = `Alva Canary`;
+	}
 
-		if (channel === 'beta') {
-			manifest.build.productName = `Alva Beta`;
-		}
+	if (channel === 'beta') {
+		manifest.build.productName = `Alva Beta`;
+	}
 
+	if (channel === 'alpha' && !cli.dryRun) {
+		await execa.shell('cp ./src/resources/alpha/* ./src/resources', { cwd: projectPath });
+	}
+
+	if (cli.debug) {
+		console.log(manifest);
+	}
+
+	if (!cli.dryRun) {
 		await execa('electron-builder', ['--publish', 'always', ...cli._], {
 			cwd: projectPath,
 			stdio: 'inherit'

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -61,7 +61,7 @@ async function main(cli) {
 
 	const channel = branch === 'master'
 		? 'alpha'
-		: `pr-${process.env.CIRCLE_PULL_REQUEST}`
+		: 'pr'
 
 	const major = semverUtils.parse(branch === 'master' ? semver.inc(manifest.version, 'major') : manifest.version);
 	const majorTarget = `${major.major}.${major.minor}.${major.patch}-${channel}.0+${hash}`;
@@ -80,7 +80,10 @@ async function main(cli) {
 
 	const iterations = releaseVersions.filter(sv);
 	const iteration = iterations[0] || majorTarget;
-	const version =  semver.inc(iteration, 'prerelease');
+
+	const version = channel === 'pr'
+		? `${major.major}.${major.minor}.${major.patch}-${channel}.${process.env.CIRCLE_PULL_REQUEST}+${hash}`
+		: semver.inc(iteration, 'prerelease');
 
 	console.log(`${prefix}${manifest.name}@${version}`);
 

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -11,9 +11,6 @@ const Util = require('util');
 
 const writeFile = Util.promisify(Fs.writeFile);
 
-const PR_NUMBER = process.env.CI_PULL_REQUEST ? Path.basename(process.env.CI_PULL_REQUEST) : '';
-const CHANNEL = PR_NUMBER ? `issue-${PR_NUMBER}` : `branch-${process.env.CIRCLE_WORKFLOW_ID}`;
-
 async function main(cli) {
 	if (!cli.project) {
 		console.log(`--project is required`);
@@ -58,7 +55,9 @@ async function main(cli) {
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 	const [hash] = (await execa('git', ['rev-parse', '--short', 'HEAD'])).stdout.split('\n');
 
-	const channel = branch === 'master' ? 'alpha' : CHANNEL;
+	const channel = branch === 'master'
+		? 'alpha'
+		: branch.split('/').join('-');
 
 	const major = semverUtils.parse(branch === 'master' ? semver.inc(manifest.version, 'major') : manifest.version);
 	const majorTarget = `${major.major}.${major.minor}.${major.patch}-${channel}.0+${hash}`;

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -33,7 +33,7 @@ async function main(cli) {
 	}
 
 	const projectPath = Path.resolve(process.cwd(), cli.project);
-	const manifest = require(Path.join(projectPath, 'package.json'));
+	const manifest = require(Path.join(projectPath, 'package.ncc.json'));
 
 	const giturl =
 		typeof manifest.repository === 'object' ? manifest.repository.url : manifest.repository;
@@ -83,7 +83,7 @@ async function main(cli) {
 
 	if (!cli.dryRun) {
 		manifest.version = version;
-		await writeFile(Path.join(projectPath, 'package.json'), JSON.stringify(manifest, null, '  '));
+		await writeFile(Path.join(projectPath, 'package.ncc.json'), JSON.stringify(manifest, null, '  '));
 	}
 }
 

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -55,9 +55,13 @@ async function main(cli) {
 	const [branch] = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.split('\n');
 	const [hash] = (await execa('git', ['rev-parse', '--short', 'HEAD'])).stdout.split('\n');
 
+	if (branch !== 'master' && !process.env.CIRCLE_PULL_REQUEST) {
+		console.log(`${prefix}skipping, not on master or pr`);
+	}
+
 	const channel = branch === 'master'
 		? 'alpha'
-		: branch.split('/').join('-');
+		: `pr-${process.env.CIRCLE_PULL_REQUEST}`
 
 	const major = semverUtils.parse(branch === 'master' ? semver.inc(manifest.version, 'major') : manifest.version);
 	const majorTarget = `${major.major}.${major.minor}.${major.patch}-${channel}.0+${hash}`;

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -81,8 +81,14 @@ async function main(cli) {
 	const iterations = releaseVersions.filter(sv);
 	const iteration = iterations[0] || majorTarget;
 
+	const prSegments = process.env.CIRCLE_PULL_REQUEST
+		? process.env.CIRCLE_PULL_REQUEST.split('/').filter(Boolean)
+		: ['0'];
+
+	const prNumber = prSegments[prSegments.length - 1] || '0';
+
 	const version = channel === 'pr'
-		? `${major.major}.${major.minor}.${major.patch}-${channel}.${process.env.CIRCLE_PR_NUMBER}+${hash}`
+		? `${major.major}.${major.minor}.${major.patch}-${channel}.${prNumber}+${hash}`
 		: semver.inc(iteration, 'prerelease');
 
 	if (version === null) {

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -82,7 +82,7 @@ async function main(cli) {
 	const iteration = iterations[0] || majorTarget;
 
 	const version = channel === 'pr'
-		? `${major.major}.${major.minor}.${major.patch}-${channel}.${process.env.CIRCLE_PULL_REQUEST}+${hash}`
+		? `${major.major}.${major.minor}.${major.patch}-${channel}.${process.env.CIRCLE_PR_NUMBER}+${hash}`
 		: semver.inc(iteration, 'prerelease');
 
 	if (version === null) {

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -85,6 +85,11 @@ async function main(cli) {
 		? `${major.major}.${major.minor}.${major.patch}-${channel}.${process.env.CIRCLE_PULL_REQUEST}+${hash}`
 		: semver.inc(iteration, 'prerelease');
 
+	if (version === null) {
+		console.error(`Failed to determine new version from ${iteration}`);
+		process.exit(1);
+	}
+
 	console.log(`${prefix}${manifest.name}@${version}`);
 
 	if (!cli.dryRun) {

--- a/packages/tools/alva-trigger.js
+++ b/packages/tools/alva-trigger.js
@@ -12,7 +12,7 @@ const Util = require('util');
 const writeFile = Util.promisify(Fs.writeFile);
 
 const PR_NUMBER = process.env.CI_PULL_REQUEST ? Path.basename(process.env.CI_PULL_REQUEST) : '';
-const CHANNEL = PR_NUMBER ? `issue-${PR_NUMBER}` : `branch`;
+const CHANNEL = PR_NUMBER ? `issue-${PR_NUMBER}` : `branch-${process.env.CIRCLE_WORKFLOW_ID}`;
 
 async function main(cli) {
 	if (!cli.project) {
@@ -60,7 +60,7 @@ async function main(cli) {
 
 	const channel = branch === 'master' ? 'alpha' : CHANNEL;
 
-	const major = semverUtils.parse( branch === 'master' ? semver.inc(manifest.version, 'major') : manifest.version);
+	const major = semverUtils.parse(branch === 'master' ? semver.inc(manifest.version, 'major') : manifest.version);
 	const majorTarget = `${major.major}.${major.minor}.${major.patch}-${channel}.0+${hash}`;
 
 	const releaseVersions = sortedReleases

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,15 +1895,10 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
-acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2:
+acorn@5.7.3, acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2, acorn@^6.0.1:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-
-acorn@^6.0.1:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
-  integrity sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==
 
 agent-base@4, agent-base@^4.1.0, agent-base@~4.2.0:
   version "4.2.1"
@@ -11384,14 +11379,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
-  dependencies:
-    source-map "^0.5.6"
-
-source-map-support@^0.5.0, source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.6:
+source-map-support@^0.4.15, source-map-support@^0.5.0, source-map-support@^0.5.6, source-map-support@^0.5.9, "source-map-support@npm:@marionebl/source-map-support", source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/@marionebl/source-map-support/-/source-map-support-0.5.9.tgz#44432dfbf3ca48cda75049c2d60d94e3cfbd6df0"
   integrity sha512-BizIVFfem13RXMrVNL5MF9Xx/+2GWLidYnITnOZb33yQk/wrDRiuLF9ZyGT1WsvJTaYbVDKZljSHQ5k29dyb2A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,6 +1839,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@zeit/ncc@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.8.1.tgz#f24982591fe0e2a0f2c53e59e533837eddb8b891"
+  integrity sha512-AFgYOmh8gVRd8Bzkvygvbhdq6DayCc+O++bcGr+TFQcsHLWa6Lx9L55VVGU8sVEJibX/6BkDgcrJFZ3vYbh/ww==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -8582,6 +8587,11 @@ ncp@0.4.x:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
   integrity sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
   version "2.2.4"


### PR DESCRIPTION
* Save weight in final apps by bundling main process stuff via ncc
* Build via `ncc` to `nccbuild`
* Operate `electron-builder`in `nccbuild`
* Introduce `package.ncc.json`, gets copied to `nccbuild`