### PR TITLE
fix: do not duplicate components with multiple exports

### DIFF
--- a/packages/core/src/matchers/connect-pattern-library-request.ts
+++ b/packages/core/src/matchers/connect-pattern-library-request.ts
@@ -86,6 +86,7 @@ export function connectPatternLibrary({
 			app.send({
 				type: M.MessageType.ConnectPatternLibraryResponse,
 				id: m.id,
+				transaction: m.transaction,
 				payload: {
 					analysis: analysisResult.result,
 					path,
@@ -96,6 +97,7 @@ export function connectPatternLibrary({
 			app.send({
 				type: M.MessageType.UpdatePatternLibraryResponse,
 				id: m.id,
+				transaction: m.transaction,
 				payload: {
 					analysis: analysisResult.result,
 					path,

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -46,8 +46,8 @@ export interface RenderPage {
 export type LibraryAnalysisResult = LibraryAnalysisSuccess | LibraryAnalysisError;
 
 export enum LibraryAnalysisResultType {
-	Success,
-	Error
+	Success = 'LibraryAnalysisSuccess',
+	Error = 'LibraryAnalysisError'
 }
 
 export interface LibraryAnalysis {
@@ -79,6 +79,7 @@ export interface InternalPatternAnalysis {
 	path: string;
 	pattern: SerializedModel.SerializedPattern;
 	properties: PropertyAnalysis[];
+	symbol: Ts.Symbol;
 }
 
 export interface PatternAnalysis {


### PR DESCRIPTION
This fixes a bug where importing components with multiple exports would cause duplicated and functionally equivalent entries in the component list.