### PR TITLE
fix: avoid filling in superfluous props

### DIFF
--- a/packages/model/src/element/element-property/element-property.ts
+++ b/packages/model/src/element/element-property/element-property.ts
@@ -148,18 +148,22 @@ export class ElementProperty {
 	}
 
 	public getValue(): Types.ElementPropertyValue {
-		if (this.referencedUserStoreProperty && this.patternProperty) {
+		if (!this.patternProperty) {
+			return undefined;
+		}
+
+		if (this.referencedUserStoreProperty) {
 			const referencedValue = this.referencedUserStoreProperty.getValue();
 			return this.patternProperty.coerceValue(referencedValue);
 		}
 
 		const concreteValue = this.getConcreteValue();
 
-		if (typeof concreteValue !== 'undefined' && this.patternProperty) {
+		if (typeof concreteValue !== 'undefined') {
 			return this.patternProperty.coerceValue(concreteValue);
 		}
 
-		return this.getDefaultValue();
+		return this.patternProperty.getRequired() ? this.getDefaultValue() : undefined;
 	}
 
 	public getRawValue(): string {

--- a/packages/model/src/pattern/pattern-slot.ts
+++ b/packages/model/src/pattern/pattern-slot.ts
@@ -92,6 +92,10 @@ export class PatternSlot {
 		return this.propertyName;
 	}
 
+	public getRequired(): boolean {
+		return this.required;
+	}
+
 	public getType(): Types.SlotType {
 		return this.type;
 	}


### PR DESCRIPTION
Instead of filling all props with coerced default values for props leave them undefined if possible (that is, if they are typed as optional)