### PR TITLE
fix: ensure correct zIndex for chrome switch

### DIFF
--- a/packages/components/src/drag-area/target-signal.tsx
+++ b/packages/components/src/drag-area/target-signal.tsx
@@ -20,7 +20,7 @@ const StyledTargetSignal = styled.div`
 	margin-top: -${getSpace(SpaceSize.XS)}px;
 	margin-bottom: -${getSpace(SpaceSize.XS)}px;
 	left: ${getSpace(SpaceSize.L)}px;
-	z-index: 10;
+	z-index: 3;
 
 	&::before {
 		content: '';

--- a/packages/core/src/container/chrome/chrome-switch.tsx
+++ b/packages/core/src/container/chrome/chrome-switch.tsx
@@ -94,7 +94,9 @@ export class ChromeSwitch extends React.Component {
 									styles={{
 										container: (base: any) => ({
 											...base,
-											display: 'flex'
+											display: 'flex',
+											position: 'relative',
+											zIndex: 20
 										}),
 										menu: (base: any) => ({
 											...base,

--- a/packages/core/src/container/chrome/chrome-switch.tsx
+++ b/packages/core/src/container/chrome/chrome-switch.tsx
@@ -95,7 +95,6 @@ export class ChromeSwitch extends React.Component {
 										container: (base: any) => ({
 											...base,
 											display: 'flex',
-											position: 'relative',
 											zIndex: 20
 										}),
 										menu: (base: any) => ({


### PR DESCRIPTION
Ensure correct zIndex for Chrome Switch (the switch used for showing/hiding panes on the top left), that you can click on 'Pages' without problems. 

Before that, there was an element with a higher zIndex, so clicking on 'Pages' didn't do anything.