### PR TITLE
Update 'Get Started' link

### DIFF
--- a/packages/core/src/container/splash-screen-container.tsx
+++ b/packages/core/src/container/splash-screen-container.tsx
@@ -67,7 +67,7 @@ export class SplashScreenContainer extends React.Component {
 					app.send({
 						type: MessageType.OpenExternalURL,
 						id: uuid.v4(),
-						payload: 'https://meetalva.io/doc/docs/guides/start?guides-enabled=true'
+						payload: 'https://meetalva.io/doc/docs/start?guides-enabled=true'
 					});
 				}}
 				onExampleClick={() => {


### PR DESCRIPTION
Updated the get started link because the previous one was giving an error.

## Proposed Changes
Short description of the changes:
* Update the 'Get Started' link in splash screen

### Linked Issues
Fixes #[794](https://github.com/meetalva/alva/issues/794)
