### PR TITLE
fix(core): fix broken getting started link on splash screen

### DIFF
--- a/packages/core/src/container/splash-screen-container.tsx
+++ b/packages/core/src/container/splash-screen-container.tsx
@@ -67,7 +67,7 @@ export class SplashScreenContainer extends React.Component {
 					app.send({
 						type: MessageType.OpenExternalURL,
 						id: uuid.v4(),
-						payload: 'https://meetalva.io/doc/docs/guides/start?guides-enabled=true'
+						payload: 'https://meetalva.io/doc/docs/start'
 					});
 				}}
 				onExampleClick={() => {


### PR DESCRIPTION
## Proposed Changes
Short description of the changes:
* spash screen getting started link was pointing to a non existent page which resulted in a 404

### Checklist
- n/a

### Linked Issues
n/a
